### PR TITLE
fix: MCP numbers (49→43), slug fixes, docs cleanup

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "FinAI Research Workflow",
-  "description": "End-to-end AI agent pipeline for economic and financial academic research. Integrates 49 MCP data servers (academic papers, A-share data, US equities, macroeconomic indicators), 49 econometric methods (DID/IV/RDD/PSM/GMM and modern variants) at JF/JFE/RFS journal standard, 17 AI skills, and 34 journal templates (including top Chinese journals: 经济研究, 金融研究, 管理世界). Supports multi-agent debate for adversarial peer review. Distributed under MIT License.",
+  "description": "End-to-end AI agent pipeline for economic and financial academic research. Integrates 43 MCP data servers (academic papers, A-share data, US equities, macroeconomic indicators), 49 econometric methods (DID/IV/RDD/PSM/GMM and modern variants) at JF/JFE/RFS journal standard, 17 AI skills, and 70 journal templates (including top Chinese journals: 经济研究, 金融研究, 管理世界). Supports multi-agent debate for adversarial peer review. Distributed under MIT License.",
   "creators": [
     {
       "name": "FinAI Research Workflow Contributors",

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -42,11 +42,11 @@ abstract: |
   the entire research workflow for economic and financial scholars: from
   literature review and idea generation, through empirical design and data
   acquisition, to LaTeX paper writing and submission-ready formatting.
-  The system integrates 49 Model Context Protocol (MCP) data servers covering
+  The system integrates 43 Model Context Protocol (MCP) data servers covering
   academic papers, A-share data, US equities, macroeconomic indicators, and
   alternative data; 49 econometric methods (DID/IV/RDD/PSM/GMM and modern
   variants) at JF/JFE/RFS journal standard; 17 specialized AI skills; and
-  34 journal templates (including top Chinese journals: 经济研究, 金融研究,
+  70 journal templates (including top Chinese journals: 经济研究, 金融研究,
   管理世界). The pipeline enforces Human-in-the-Loop (HITL) checkpoints
   with full data provenance tracking, and supports multi-agent debate
   for adversarial peer review. Distributed under MIT License.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@
 
 1. Fork 本仓库
 2. 创建功能分支：`git checkout -b feature/your-feature-name`
-3. 编写代码并确保测试通过：`python scripts/agent.py --test`
+3. 编写代码并确保测试通过：`pytest tests/` 或 `finai test`
 4. 提交：`git commit -m "feat: add something useful"`
 5. 推送到您的 Fork：`git push origin feature/your-feature-name`
 6. 发起 Pull Request
@@ -23,20 +23,22 @@
 
 - 遵循 PEP 8，使用 `ruff check scripts/` 检查
 - 所有新增功能必须有对应的测试
-- 提交前运行完整测试：`python scripts/agent.py --test`
+- 提交前运行完整测试：`pytest tests/` 或 `finai test`
 
 ### 测试要求
 
 ```bash
 # 运行所有测试
-python scripts/agent.py --test
+pytest tests/
+
+# 或通过 CLI（支持 --cov, --exitfirst, -k 过滤）
+finai test --cov
 
 # 运行单个模块测试
-.venv/bin/python -m pytest scripts/core/test_memory.py -v
-.venv/bin/python -m pytest scripts/core/test_planner.py -v
-.venv/bin/python -m pytest scripts/core/test_tool_selector.py -v
-.venv/bin/python -m pytest scripts/core/test_reflector.py -v
-.venv/bin/python -m pytest scripts/core/test_session.py -v
+.venv/bin/python -m pytest tests/test_llm_reviewer.py -v
+.venv/bin/python -m pytest tests/test_modern_did.py -v
+.venv/bin/python -m pytest tests/test_checkpoint.py -v
+.venv/bin/python -m pytest tests/test_event_monitor.py -v
 ```
 
 ## 模块说明

--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,15 +1,10 @@
-# You can set up funding on GitHub Sponsors, Open Collective, or Ko-fi.
+# Funding configuration for FinAI Research Workflow
+#
+# GitHub Sponsors: https://github.com/sponsors/csmar432
+#   (Requires you to enable GitHub Sponsors separately at github.com/sponsors/csmar432)
+# Custom: 爱发电 (Afdian) - already configured below
+#
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-funding-files
 
-# These are supported funding platform targets
-github: []  # Your GitHub username or org for GitHub Sponsors
-patreon: []  # Replace with a single Patreon username
-open_collective: []  # Replace with a single Open Collective username
-ko_fi: []  # Replace with a single Ko-fi username
-tidelift: []  # Replace with a single Tidelift platform URL (e.g. "npm/babel")
-community_bridge: []  # Replace with a single Community Bridge project name (e.g. "ethereum")
-liberapay: []  # Replace with a single Liberapay username
-issuehunt: []  # Replace with a single IssueHunt username
-otechie: []  # Replace with a single Otechie username
-lfx_crowdfunding: []  # Replace with a single LFX Crowdfunding project name
-custom: ["https://afdian.net/a/finresearch"]  # Replace with up to 4 custom sponsorship URLs
+github: csmar432  # Your GitHub username for GitHub Sponsors
+custom: ["https://afdian.net/a/finresearch"]

--- a/PROFILE_README.md
+++ b/PROFILE_README.md
@@ -8,7 +8,7 @@
 
 ## 🚀 我做了什么
 
-- **FinAI Research Workflow** — 端到端 AI 学术研究工作流（49 个 MCP 数据源、49 个计量方法、17 个 AI 技能、34 种期刊模板）
+- **FinAI Research Workflow** — 端到端 AI 学术研究工作流（43 个 MCP 数据源、49 个计量方法、17 个 AI 技能、70 种期刊模板）
 - **论文写作 / 文献综述 / 实证设计** 自动化
 - 集成 Claude Code / Cursor / GitHub Copilot 的多工具适配
 
@@ -20,7 +20,7 @@
 
 ```
 AI/ML     : LLM-based agents · 检索增强生成 (RAG) · 工具调用
-数据获取   : MCP 协议 (49 个数据服务器) · akshare · Tushare · yfinance · ArXiv · OpenAlex
+数据获取   : MCP 协议 (43 个数据服务器) · akshare · Tushare · yfinance · ArXiv · OpenAlex
 计量经济   : DID (Callaway-Sant'Anna, Sun-Abraham, Goodman-Bacon)
            IV/RDD · 合成控制 · 面板 GMM · 局部投影
 论文工具   : LaTeX (CTeX/ACLTEX) · BibTeX · matplotlib/seaborn (300+ DPI)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # 论文-研报工作流 · FinResearch Agent
 
+![Banner](.github/demo/banner.svg)
+
 > 经济金融领域 AI 学术研究工作流 — 从研究想法到可投稿论文。集成 MCP 数据获取、因果推断（DID/IV/PSM/GMM）、LaTeX 排版和对抗性 review 循环。
 
 [![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12-3776AB?logo=python&logoColor=white)](https://pypi.org/project/finai-research-workflow/)
@@ -7,14 +9,14 @@
 [![PyPI version](https://img.shields.io/pypi/v/finai-research-workflow?color=blue)](https://pypi.org/project/finai-research-workflow/)
 [![PyPI downloads](https://img.shields.io/pypi/dm/finai-research-workflow?color=blue)](https://pypi.org/project/finai-research-workflow/)
 [![arXiv](https://img.shields.io/badge/arXiv-cs.AI-b31b1b.svg)](https://arxiv.org/)
-[![CI](https://img.shields.io/github/actions/workflow/status/csmar432/论文-研报工作流/ci.yml?branch=main&label=CI)](https://github.com/csmar432/论文-研报工作流/actions)
-[![docs](https://img.shields.io/github/actions/workflow/status/csmar432/论文-研报工作流/docs.yml?branch=main&label=docs)](https://github.com/csmar432/论文-研报工作流/actions)
+[![CI](https://img.shields.io/github/actions/workflow/status/csmar432/finai-research-workflow/ci.yml?branch=main&label=CI)](https://github.com/csmar432/finai-research-workflow/actions)
+[![docs](https://img.shields.io/github/actions/workflow/status/csmar432/finai-research-workflow/docs.yml?branch=main&label=docs)](https://github.com/csmar432/finai-research-workflow/actions)
 [![codecov](https://codecov.io/gh/csmar432/finai-research-workflow/branch/main/graph/badge.svg)](https://codecov.io/gh/csmar432/finai-research-workflow)
 [![Security: bandit](https://img.shields.io/badge/security-bandit-yellow.svg)](https://github.com/PyCQA/bandit)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 [![Code style: ruff](https://img.shields.io/badge/code%20style-ruff-000000.svg)](https://github.com/astral-sh/ruff)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.finai-research-workflow.svg)](https://doi.org/10.5281/zenodo.finai-research-workflow)
-[![GitHub stars](https://img.shields.io/github/stars/csmar432/论文-研报工作流?style=social)](https://github.com/csmar432/论文-研报工作流/stargazers)
+[![GitHub stars](https://img.shields.io/github/stars/csmar432/finai-research-workflow?logo=github&logoColor=white&color=yellow)](https://github.com/csmar432/finai-research-workflow/stargazers)
 
 ---
 <!--
@@ -22,6 +24,23 @@
 -->
 
 **Languages**: 🇨🇳 [简体中文](README.md) (默认) · 🇬🇧 [English](README_EN.md)
+
+---
+
+## ⚡ Quick Start
+
+```bash
+# 1. Install
+pip install -e .          # or: git clone + pip install -r requirements.txt
+
+# 2. Check environment
+python scripts/health_check.py --json
+
+# 3. Run your first research pipeline
+python scripts/research_framework/pipeline.py --topic "碳排放权交易对企业绿色创新的影响"
+```
+
+> More in [5-Minute Setup](#5-minute-setup) below, or jump to [docs/tutorials/01-quickstart.md](docs/tutorials/01-quickstart.md).
 
 ---
 
@@ -132,7 +151,7 @@ python scripts/demo_research_report.py
 ### What Works Cross-Platform
 
 - ✅ All `scripts/*.py` entry points
-- ✅ 44 MCP servers (pure Python stdlib)
+- ✅ 43 MCP servers (pure Python stdlib)
 - ✅ Checkpoint (`fcntl.flock` falls back to no-op on Windows)
 - ✅ 170 unit tests (CI matrix runs on Ubuntu + macOS + Windows)
 
@@ -158,16 +177,16 @@ Describe your research in plain Chinese — the agent handles the rest:
 |-------|--------|
 | Literature Review | Citation graph + gap analysis (arXiv / NBER / OpenAlex / JF / JFE / RFS) |
 | Research Design | DID/IV/RDD identification strategy + data sourcing plan |
-| Empirical Analysis | 42 econometric methods, automated robustness tests (19 types) |
+| Empirical Analysis | 49 econometric methods, automated robustness tests (19 types) |
 | Paper Draft | LaTeX manuscript in journal format (JF/JFE/RFS/经济研究/金融研究/管理世界) |
 | Review Loop | Adversarial review until submission-ready |
 
 **Architecture overview:**
 
 ![Architecture Diagram](.github/demo/architecture-diagram.svg)
-*Multi-agent pipeline: User Input → AI Agent → 8-Stage Research Pipeline → 50 MCP Servers → 42 Econometric Methods → 20 Chart Types → LaTeX Paper*
+*Multi-agent pipeline: User Input → AI Agent → 8-Stage Research Pipeline → 43 MCP Servers → 49 Econometric Methods → 20 Chart Types → LaTeX Paper*
 
-> **Note:** Screenshots and demo videos coming soon. The project is actively maintained.
+> **Architecture** diagram above (`.github/demo/architecture-diagram.svg`). **Live demo:** record a GIF with [LICEcap](https://www.cockos.com/licecap/) or [ScreenToGif](https://www.screentogif.com/) and add it here to boost engagement.
 
 ---
 
@@ -178,7 +197,7 @@ Describe your research in plain Chinese — the agent handles the rest:
 - **Write academic papers** — From literature review to LaTeX submission (JF/JFE/RFS/经济研究/金融研究/管理世界)
 - **Generate research reports** — Institutional-grade financial analysis for A-shares and global markets
 - **Run empirical analysis** — DID, IV, PSM, Panel GMM with automated validation
-- **Access financial data** — A-shares, US stocks, macro indicators via 50 MCP data servers (most require no API key)
+- **Access financial data** — A-shares, US stocks, macro indicators via 43 MCP data servers (most require no API key)
 
 > Architecture principle: **Local LLM (Claude Code / Cursor) as the core, external AI as supplement.**
 
@@ -189,8 +208,8 @@ Describe your research in plain Chinese — the agent handles the rest:
 | Feature | Description |
 |---------|-------------|
 | **Multi-Agent Pipeline** | Orchestrates 5-paper agents (outline → literature → plotting → writing → refinement) |
-| **50 MCP Data Servers** | A-share (Tushare), macro (World Bank, IMF, OECD), US stocks (yfinance), academic (ArXiv, NBER, OpenAlex), SEC filings, ESG, options, forex, shipping, commodities, crypto, Chinese patents, customs data, fund/bond/option data, provincial statistics — most require no API key |
-| **49+ Econometric Methods** | DID (5 variants), RDD, synthetic control, panel GMM, spatial regression, IV/2SLS, causal ML, GARCH, survival analysis, panel cointegration — JF/JFE/RFS standard |
+| **43 MCP Data Servers** | A-share (Tushare), macro (World Bank, IMF, OECD), US stocks (yfinance), academic (ArXiv, NBER, OpenAlex), SEC filings, ESG, options, forex, shipping, commodities, crypto, Chinese patents, customs data, fund/bond/option data, provincial statistics — most require no API key |
+| **49 Econometric Methods** | DID (5 variants), RDD, synthetic control, panel GMM, spatial regression, IV/2SLS, causal ML, GARCH, survival analysis, panel cointegration — JF/JFE/RFS standard |
 | **Provenance Tracking** | Full data lineage from raw API to final chart/table |
 | **HITL Gates** | Human-in-the-loop approval at critical pipeline stages |
 | **6 Financial Analysts** | Parallel analysis: fundamental, valuation, risk, earnings, competitive, macro |
@@ -205,7 +224,7 @@ Describe your research in plain Chinese — the agent handles the rest:
 
 ```bash
 # 1. Clone the repository
-git clone https://github.com/finai-research/finai-research-workflow.git
+git clone https://github.com/csmar432/finai-research-workflow.git
 cd finai-research-workflow
 
 # 2. Install dependencies
@@ -262,7 +281,7 @@ The system uses a **layered agent architecture** with an AI Agent (Claude Code /
 └─────────────────┘  └─────────────────┘  └──────────────────────────┘
 ```
 
-**Key numbers:** 50 MCP servers · 42 econometric methods · 17 Skills · 45 journal templates · 20 chart types · 19 robustness checks · 12 research directions
+**Key numbers:** 43 MCP servers · 49 econometric methods · 17 Skills · 45 journal templates · 20 chart types · 19 robustness checks · 12 research directions
 
 ---
 
@@ -449,7 +468,7 @@ This project is licensed under the MIT License. See [LICENSE](LICENSE) for detai
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=csmar432/论文-研报工作流&type=Timeline)](https://star-history.com/#csmar432/论文-研报工作流&Timeline)
+[![Star History Chart](https://api.star-history.com/svg?repos=csmar432/finai-research-workflow&type=Timeline)](https://star-history.com/#csmar432/finai-research-workflow&Timeline)
 
 ---
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,5 +1,7 @@
 # FinAI Research Workflow
 
+![Banner](.github/demo/banner.svg)
+
 > End-to-end AI agent pipeline for economic and financial academic research — from research idea to submission-ready paper. Integrates MCP data acquisition, causal inference (DID/IV/PSM/GMM), LaTeX typesetting, and adversarial review loops.
 
 [![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12-3776AB?logo=python&logoColor=white)](https://pypi.org/project/finai-research-workflow/)
@@ -7,11 +9,11 @@
 [![PyPI version](https://img.shields.io/pypi/v/finai-research-workflow?color=blue)](https://pypi.org/project/finai-research-workflow/)
 [![PyPI downloads](https://img.shields.io/pypi/dm/finai-research-workflow?color=blue)](https://pypi.org/project/finai-research-workflow/)
 [![arXiv](https://img.shields.io/badge/arXiv-cs.AI-b31b1b.svg)](https://arxiv.org/)
-[![CI](https://img.shields.io/github/actions/workflow/status/csmar432/论文-研报工作流/ci.yml?branch=main&label=CI)](https://github.com/csmar432/论文-研报工作流/actions)
-[![docs](https://img.shields.io/github/actions/workflow/status/csmar432/论文-研报工作流/docs.yml?branch=main&label=docs)](https://github.com/csmar432/论文-研报工作流/actions)
+[![CI](https://img.shields.io/github/actions/workflow/status/csmar432/finai-research-workflow/ci.yml?branch=main&label=CI)](https://github.com/csmar432/finai-research-workflow/actions)
+[![docs](https://img.shields.io/github/actions/workflow/status/csmar432/finai-research-workflow/docs.yml?branch=main&label=docs)](https://github.com/csmar432/finai-research-workflow/actions)
 [![codecov](https://codecov.io/gh/csmar432/finai-research-workflow/branch/main/graph/badge.svg)](https://codecov.io/gh/csmar432/finai-research-workflow)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.finai-research-workflow.svg)](https://doi.org/10.5281/zenodo.finai-research-workflow)
-[![GitHub stars](https://img.shields.io/github/stars/csmar432/论文-研报工作流?style=social)](https://github.com/csmar432/论文-研报工作流/stargazers)
+[![GitHub stars](https://img.shields.io/github/stars/csmar432/finai-research-workflow?logo=github&logoColor=white&color=yellow)](https://github.com/csmar432/finai-research-workflow/stargazers)
 
 [🇨🇳 **中文文档**](README.md) · [🇬🇧 **English Documentation**](#)
 
@@ -55,7 +57,7 @@
 
 ## ✨ Core Capabilities
 
-### 📊 Data Acquisition (50 MCP Servers, mostly no API key required)
+### 📊 Data Acquisition (43 MCP Servers, mostly no API key required)
 
 | What you need | MCP server |
 |---|---|
@@ -143,7 +145,7 @@ Step 2  Idea ↔ Data verify  → scripts/idea_data_checker.py (HITL checkpoint)
 Step 3  Literature review   → MCP multi-source, citation network, gap analysis
 Step 4  Novelty check       → JF/JFE/RFS/arXiv search
 Step 5  Empirical design    → DID/IV/RD/PSM/18 robustness checks
-Step 6  Data acquisition    → 50 MCP servers, 4-layer fallback
+Step 6  Data acquisition    → 43 MCP servers, 4-layer fallback
 Step 7  Paper writing       → outline → draft → figures → LaTeX
 Step 8  Adversarial review  → multi-round, until publishable
 ```
@@ -156,7 +158,7 @@ Each step is **independently callable** and **has its own output file** as a sta
 
 | Metric | Value |
 |---|---|
-| MCP data servers | **49** |
+| MCP data servers | **43** |
 | Tools exposed | **222** |
 | Econometric methods | **49** |
 | AI skills | **17** |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@ If you discover a security vulnerability, please report it responsibly:
 
 1. **Do NOT** open a public GitHub Issue.
 2. Send a private disclosure to the maintainers via:
-   - GitHub Security Advisories (preferred): [Report a vulnerability](https://github.com/csmar432/论文-研报工作流/security/advisories/new)
+   - GitHub Security Advisories (preferred): [Report a vulnerability](https://github.com/csmar432/finai-research-workflow/security/advisories/new)
    - Or email the maintainers directly.
 
 3. Please include as much of the following as possible:

--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -197,7 +197,7 @@ Add to Cursor MCP settings:
 pip install tushare
 
 # Configure token
-echo "TUSHARE_TOKEN=your-token" >> .env
+echo "TUSHARE_TOKEN=your-tushare-token" >> .env
 ```
 
 #### user-financial (全球宏观)
@@ -214,7 +214,7 @@ echo "TUSHARE_TOKEN=your-token" >> .env
 pip install eodhd
 
 # Configure key
-echo "EODHD_API_KEY=your-key" >> .env
+echo "EODHD_API_KEY=your-eodhd-api-key" >> .env
 ```
 
 ---
@@ -401,7 +401,7 @@ pip install -e .
 
 ### Getting Help
 
-1. Check existing issues: [GitHub Issues](https://github.com/csmar432/论文-研报工作流/issues)
+1. Check existing issues: [GitHub Issues](https://github.com/csmar432/finai-research-workflow/issues)
 2. Run with verbose logging:
 
 ```bash

--- a/docs/PUBLISHING_GUIDE.md
+++ b/docs/PUBLISHING_GUIDE.md
@@ -34,8 +34,8 @@
 
 ```
 End-to-end AI agent pipeline for economic and financial research. 
-49 MCP data servers, 49 econometric methods (DID/IV/RDD/PSM), 
-17 AI skills, 34 journal templates. 
+43 MCP data servers, 49 econometric methods (DID/IV/RDD/PSM), 
+17 AI skills, 70 journal templates. 
 Designed for JF/JFE/RFS/经济研究/金融研究 submissions.
 ```
 

--- a/docs/REPOSITORY_SETUP.md
+++ b/docs/REPOSITORY_SETUP.md
@@ -67,8 +67,8 @@
 - 📝 **Description**: 
   ```
   End-to-end AI agent pipeline for economic and financial research. 
-  49 MCP data servers, 49 econometric methods (DID/IV/RDD/PSM), 
-  17 AI skills, 34 journal templates.
+  43 MCP data servers, 49 econometric methods (DID/IV/RDD/PSM),
+  17 AI skills, 70 journal templates.
   ```
 - 🔗 **Website**: 可指向 GitHub Pages
 - ⭐ **Topics**: 见 #7

--- a/docs/YOUR_SPECIFIC_FIX.md
+++ b/docs/YOUR_SPECIFIC_FIX.md
@@ -59,7 +59,7 @@
    - **Description**: 英文短描述
      ```
      End-to-end AI agent pipeline for economic and financial research. 
-     49 MCP data sources, 49 econometric methods, 17 AI skills.
+     43 MCP data sources, 49 econometric methods, 17 AI skills.
      ```
    - **Public** ✅ (必须)
    - ❌ 不要勾选 "Initialize with README" (会冲突本地)

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -4,10 +4,10 @@
 site_name: FinResearch Agent 文档
 site_description: 经济金融领域 AI 学术研究工作流文档
 site_author: FinAI Research Workflow Contributors
-site_url: https://github.com/csmar432/论文-研报工作流
+site_url: https://csmar432.github.io/finai-research-workflow
 
-repo_name: csmar432/论文-研报工作流
-repo_url: https://github.com/csmar432/论文-研报工作流
+repo_name: csmar432/finai-research-workflow
+repo_url: https://github.com/csmar432/finai-research-workflow
 edit_uri: ""
 
 theme:

--- a/examples/04-mcp-data-fetch.py
+++ b/examples/04-mcp-data-fetch.py
@@ -2,7 +2,7 @@
 """
 Example 04: MCP Data Fetching · 从 MCP 服务器拉取数据
 
-演示如何从 49 个 MCP 数据源获取金融数据。
+演示如何从 43 个 MCP 数据源获取金融数据。
 覆盖 4 层 fallback：MCP → Python lib → HTTP → synthetic。
 """
 import sys

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,7 +7,7 @@
 | 1 | [01-quickstart-pipeline.py](01-quickstart-pipeline.py) | 5 行代码跑完整研究流水线 | ⭐ |
 | 2 | [02-did-analysis.py](02-did-analysis.py) | Callaway-Sant'Anna DID 实证 | ⭐⭐ |
 | 3 | [03-paper-latex.py](03-paper-latex.py) | 自动生成可投稿 LaTeX 论文 | ⭐⭐ |
-| 4 | [04-mcp-data-fetch.py](04-mcp-data-fetch.py) | 从 49 MCP 服务器拉取数据 | ⭐ |
+| 4 | [04-mcp-data-fetch.py](04-mcp-data-fetch.py) | 从 43 MCP 服务器拉取数据 | ⭐ |
 | 5 | [05-charts-figures.py](05-charts-figures.py) | 20+ 种学术金融图表 | ⭐ |
 
 ## 🚀 快速开始

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,10 +4,10 @@
 site_name: FinResearch Agent 文档
 site_description: 经济金融领域 AI 学术研究工作流文档
 site_author: FinAI Research Workflow Contributors
-site_url: https://github.com/csmar432/论文-研报工作流
+site_url: https://csmar432.github.io/finai-research-workflow
 
-repo_name: csmar432/论文-研报工作流
-repo_url: https://github.com/csmar432/论文-研报工作流
+repo_name: csmar432/finai-research-workflow
+repo_url: https://github.com/csmar432/finai-research-workflow
 edit_uri: ""
 
 site_dir: .site

--- a/releases/v1.0.0.md
+++ b/releases/v1.0.0.md
@@ -3,13 +3,13 @@
 > **Milestone release** · 经济金融领域 AI 学术研究工作流首个 GA 版本。
 
 我们很高兴发布 **FinAI Research Workflow v1.0.0**——一个面向经济金融研究者的端到端 AI 工作流。
-从研究想法到可投稿论文，全流程自动化，集成 49 个 MCP 数据服务器、49 种计量方法、17 个 AI 技能和 6 大中文顶刊投稿标准。
+从研究想法到可投稿论文，全流程自动化，集成 43 个 MCP 数据服务器、49 种计量方法、17 个 AI 技能和 6 大中文顶刊投稿标准。
 
 ---
 
 ## ✨ 核心亮点
 
-### 📊 数据生态：49 MCP Servers
+### 📊 数据生态：43 MCP Servers
 - **学术文献** (5)：OpenAlex 2亿+ 论文 · ArXiv · Context7 全文 · Semantic Scholar · NBER
 - **A股数据** (4)：Tushare · 东方财富 · Wind · CSMAR
 - **美股/全球** (3)：Yahoo Finance · SEC EDGAR · 增强金融
@@ -46,7 +46,7 @@
 
 ### ✨ Added
 - 完整 8 步研究流水线 (idea → paper)
-- 49 MCP servers 完整 schema (222 tools)
+- 43 MCP servers 完整 schema (222 tools)
 - 49 计量方法 + 18 类稳健性检验
 - 17 技能 + 4 命令 + 22 知识文档
 - 6 大中文顶刊投稿格式

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -26,7 +26,7 @@ BANNER = """
 ║   经济金融领域 AI 学术研究工作流                            ║
 ║                                                          ║
 ║   v1.0.0 · MIT License · 2026                            ║
-║   49 MCP Servers · 49 Methods · 17 Skills                ║
+║   43 MCP Servers · 49 Methods · 17 Skills                ║
 ║                                                          ║
 ╚══════════════════════════════════════════════════════════╝
 """


### PR DESCRIPTION
## Summary

### 数字校正
- MCP 49→43 (CITATION.cff, .zenodo.json, PROFILE_README.md, scripts/cli.py, releases/v1.0.0.md, docs/PUBLISHING_GUIDE.md, docs/REPOSITORY_SETUP.md, docs/YOUR_SPECIFIC_FIX.md, examples/04-mcp-data-fetch.py, examples/README.md)
- 期刊模板 34→70 (CITATION.cff, .zenodo.json, PROFILE_README.md)

### 文档清理
- CONTRIBUTING.md: agent.py --test → pytest tests/
- FUNDING.yml: GitHub Sponsors (github: csmar432)
- SETUP_GUIDE.md: your-token → your-tushare-token / your-eodhd-api-key

### slug 统一
- README.md, README_EN.md: 中文 badge URLs → finai-research-workflow
- SECURITY.md, mkdocs.yml, SETUP_GUIDE.md: 中文 slug → finai-research-workflow

Co-authored-by: Cursor <cursoragent@cursor.com>