### PR TITLE
fix(ci): repair PR Labeler (labeler v5 schema) and Docker Build (.dockerignore negation)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -49,7 +49,10 @@ Thumbs.db
 .github/
 
 # 6) 大型数据 / 数据库 (mcp_diagnostic 默认 250MB+ 不应在镜像中)
-data/
+# 重要: 用 data/* 而非 data/，否则否定规则 !data/.gitkeep 不生效
+# (Docker 文档: 否定模式仅在父目录未被排除时生效)
+data/*
+!data/.gitkeep
 *.db
 *.sqlite
 *.sqlite3

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,83 +1,94 @@
 # .github/labeler.yml
-# Schema: actions/labeler v5 (each label value MUST be an array of config objects)
-# Docs: https://github.com/actions/labeler
+# Schema: actions/labeler v5/v6 (https://github.com/actions/labeler)
 #
-# v4 → v5 breaking change: the simple `label: [glob, glob]` form is no longer
-# accepted. Each entry must be an object with at least one of:
-#   - changed-files    (glob list)
-#   - base-branches    (branch list)
-#   - headings         (PR title regex)
-#   - title-glob       (PR title glob)
-#   - description-glob (PR body glob)
-# Glob behaviour is the same (default = match changed-files).
+# v4 → v5 breaking change: each label value MUST be an array of config
+# objects, and glob lists must be wrapped in `any-glob-to-any-file`:
+#
+#   label-name:
+#     - changed-files:
+#         - any-glob-to-any-file: ['glob1', 'glob2']
+#
+# Migration from previous file: only the wrapper changed. Glob behaviour
+# is identical (default = any-glob-to-any-file, which is the v4 semantics).
 
 # ── 代码 ──────────────────────────────────────────────────────────
 code:
   - changed-files:
-      - scripts/**
-      - mcp_servers/**/server.py
+      - any-glob-to-any-file:
+          - scripts/**
+          - mcp_servers/**/server.py
 
 tests:
   - changed-files:
-      - tests/**
+      - any-glob-to-any-file:
+          - tests/**
 
 ci:
   - changed-files:
-      - .github/workflows/**
-      - .github/labeler.yml
+      - any-glob-to-any-file:
+          - .github/workflows/**
+          - .github/labeler.yml
 
 # ── 文档 ──────────────────────────────────────────────────────────
 docs:
   - changed-files:
-      - docs/**
-      - "**/*.md"
-      - "**/*.rst"
+      - any-glob-to-any-file:
+          - docs/**
+          - "**/*.md"
+          - "**/*.rst"
 
 # ── 论文/研报 ─────────────────────────────────────────────────────
 paper:
   - changed-files:
-      - "**/*.tex"
-      - "**/*.bib"
+      - any-glob-to-any-file:
+          - "**/*.tex"
+          - "**/*.bib"
 
 output:
   - changed-files:
-      - output/**
+      - any-glob-to-any-file:
+          - output/**
 
 # ── 配置 ──────────────────────────────────────────────────────────
 config:
   - changed-files:
-      - "**/*.json"
-      - "**/*.yml"
-      - "**/*.yaml"
-      - "**/*.toml"
-      - "**/*.ini"
-      - ".env.example"
-      - "pyproject.toml"
+      - any-glob-to-any-file:
+          - "**/*.json"
+          - "**/*.yml"
+          - "**/*.yaml"
+          - "**/*.toml"
+          - "**/*.ini"
+          - ".env.example"
+          - pyproject.toml
 
 # ── 依赖 ──────────────────────────────────────────────────────────
 dependencies:
   - changed-files:
-      - "**/requirements*.txt"
-      - "**/pyproject.toml"
-      - "**/uv.lock"
-      - "**/poetry.lock"
+      - any-glob-to-any-file:
+          - "**/requirements*.txt"
+          - "**/pyproject.toml"
+          - "**/uv.lock"
+          - "**/poetry.lock"
 
 # ── 数据 (一般不进 git, 但偶尔有 schema/seed) ─────────────────────
 data:
   - changed-files:
-      - data/**
-      - "**/*.csv"
-      - "**/*.parquet"
-      - "**/*.xlsx"
+      - any-glob-to-any-file:
+          - data/**
+          - "**/*.csv"
+          - "**/*.parquet"
+          - "**/*.xlsx"
 
 # ── Skills / Knowledge ───────────────────────────────────────────
 skills:
   - changed-files:
-      - knowledge/skills/**
-      - .claude/commands/**
-      - .claude/skills/**
+      - any-glob-to-any-file:
+          - knowledge/skills/**
+          - .claude/commands/**
+          - .claude/skills/**
 
 # ── 特殊分类 ──────────────────────────────────────────────────────
 mcp:
   - changed-files:
-      - mcp_servers/**
+      - any-glob-to-any-file:
+          - mcp_servers/**


### PR DESCRIPTION
## Summary

Fix 2 pre-existing CI failures (unrelated to docs navigation). The 6 required CI checks all pass on this PR — the 2 non-required checks (PR Labeler, Docker Build) that were failing in the current main are fixed here.

## Changes

### 1. `.github/labeler.yml` — actions/labeler v5/v6 schema migration

**Problem**: v4 → v5 introduced a breaking change in the configuration format. Each label value MUST be an array of config objects, and glob lists must be wrapped in `any-glob-to-any-file`.

**Before** (v4-style, rejected by v5/v6):
```yaml
code:
  - changed-files:
      - scripts/**
      - mcp_servers/**/server.py
```

**After** (v5/v6):
```yaml
code:
  - changed-files:
      - any-glob-to-any-file:
          - scripts/**
          - mcp_servers/**/server.py
```

**Fixes**: `Error: The "changed-files" section must have a valid config structure`

### 2. `.dockerignore` — allow `data/.gitkeep` to be COPYed

**Problem**: `data/` (with trailing slash) excluded the entire directory, so the negative rule `!data/.gitkeep` had no effect — Docker's negation only works if the parent was not previously excluded.

**Before**:
```
data/
```

**After**:
```
data/*
!data/.gitkeep
```

**Fixes**: `failed to compute cache key: "/data/.gitkeep": not found` in the CI `docker build` step.

## Test Plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/labeler.yml'))"` — passes
- [x] All 11 labels confirmed to follow v5 schema (each value is an array, each element is `{changed-files: {any-glob-to-any-file: [globs]}}`)
- [x] `.dockerignore` simulation: `data/.gitkeep` is included, `data/*.json` etc. are excluded
- [ ] CI: all 10 checks should pass (was 8/10 in PR #26)

## References

- `AUDIT_ONLINE_2026-06-17.md` (P2-1 + P2-2)
- `actions/labeler` v5 docs: https://github.com/actions/labeler

## Checklist

- [x] No API keys or secrets committed
- [x] No docs changes (intentionally — `docs/api_reference.md` and `docs/tutorials/index.md` already exist correctly on `main`)
- [x] Minimal, targeted changes

Made with [Cursor](https://cursor.com)