### PR TITLE
fix(v14): QualityGates加载诊断 + DOI占位符显式化

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -46,11 +46,11 @@ abstract: |
   the entire research workflow for economic and financial scholars: from
   literature review and idea generation, through empirical design and data
   acquisition, to LaTeX paper writing and submission-ready formatting.
-  The system integrates 43 Model Context Protocol (MCP) data servers covering
+  The system integrates 44 Model Context Protocol (MCP) data servers covering
   academic papers, A-share data, US equities, macroeconomic indicators, and
   alternative data; 42 econometric methods (DID/IV/RDD/PSM/GMM and modern
   variants) at JF/JFE/RFS journal standard; 17 specialized AI skills; and
-  45 journal templates (including top Chinese journals: 经济研究, 金融研究,
+  44 journal templates (including top Chinese journals: 经济研究, 金融研究,
   管理世界). The pipeline enforces Human-in-the-Loop (HITL) checkpoints
   with full data provenance tracking, and supports multi-agent debate
   for adversarial peer review. Distributed under MIT License.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 [![Code style: ruff](https://img.shields.io/badge/code%20style-ruff-000000.svg)](https://github.com/astral-sh/ruff)
 <!-- Zenodo DOI badge: 真实发布到 Zenodo 后替换占位符。 -->
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.PENDING.svg)](https://doi.org/10.5281/zenodo.PENDING)
+[![DOI: PENDING](https://img.shields.io/badge/DOI-PENDING-orange.svg)](https://github.com/csmar432/finai-research-workflow#cite-this-work)
 [![GitHub stars](https://img.shields.io/github/stars/csmar432/finai-research-workflow?style=social)](https://github.com/csmar432/finai-research-workflow/stargazers)
 
 ---
@@ -606,7 +606,10 @@ If you use FinAI Research Workflow in published research, please cite it as:
   year   = {2026},
   month  = jun,
   url    = {https://github.com/csmar432/finai-research-workflow},
-  doi    = {10.5281/zenodo.PENDING}
+  doi    = {10.5281/zenodo.PENDING}  # NOTE: Zenodo DOI not yet activated.
+                                       # To obtain a permanent DOI, release the
+                                       # repository on Zenodo (https://zenodo.org)
+                                       # and update this field.
 }
 ```
 

--- a/scripts/agent_pipeline.py
+++ b/scripts/agent_pipeline.py
@@ -42,6 +42,7 @@ Canvas可视化：
 """
 
 import json
+import logging
 import subprocess
 import sys
 import time
@@ -53,6 +54,8 @@ from typing import Any
 # Bootstrap sys.path so `python scripts/agent_pipeline.py` works without `pip install -e .`
 from scripts.core import _bootstrap  # noqa: F401
 _bootstrap.bootstrap()
+
+logger = logging.getLogger(__name__)
 
 from scripts.core.platform import (
     PROJECT_ROOT,
@@ -1153,15 +1156,45 @@ class AgentPipeline:
         try:
             from scripts.core.quality_gates import PaperQualityGates
             self._quality_gates = PaperQualityGates(strict=False)
-        except ImportError:
+            logger.debug("[AgentPipeline] PaperQualityGates loaded successfully")
+        except ImportError as exc:
             self._quality_gates = None
+            logger.warning(
+                "[AgentPipeline] PaperQualityGates failed to import (%s) — "
+                "automatic quality gates will be NO-OP. To restore them: "
+                "pip install -e . and ensure scripts/core/quality_gates.py exists.",
+                exc,
+            )
+        except Exception as exc:  # noqa: BLE001 — must not break pipeline init
+            self._quality_gates = None
+            logger.error(
+                "[AgentPipeline] PaperQualityGates initialization error (%s) — "
+                "automatic quality gates will be NO-OP.",
+                exc,
+                exc_info=True,
+            )
 
         # ── Initialize AutoReviewRules ──────────────────────────────────────────
         try:
             from scripts.core.auto_review_rules import AutoReviewRules
             self._auto_reviewer = AutoReviewRules(domain="empirical_paper")
-        except ImportError:
+            logger.debug("[AgentPipeline] AutoReviewRules loaded successfully")
+        except ImportError as exc:
             self._auto_reviewer = None
+            logger.warning(
+                "[AgentPipeline] AutoReviewRules failed to import (%s) — "
+                "automatic peer-review simulation will be NO-OP. To restore it: "
+                "pip install -e . and ensure scripts/core/auto_review_rules.py exists.",
+                exc,
+            )
+        except Exception as exc:  # noqa: BLE001 — must not break pipeline init
+            self._auto_reviewer = None
+            logger.error(
+                "[AgentPipeline] AutoReviewRules initialization error (%s) — "
+                "automatic peer-review simulation will be NO-OP.",
+                exc,
+                exc_info=True,
+            )
 
         self._initialized = True
         # 可视化服务器延迟启动：在首个 HITL gate 触发后才启动


### PR DESCRIPTION
## v14: QualityGates 加载诊断 + DOI 占位符显式化

### A. QualityGates / AutoReviewRules 加载诊断改进
- 现状：try-import 失败 → self._quality_gates = None，无任何日志
- 修复：区分 ImportError vs 其他异常，分别给出 warning/error + 修复提示
- 行为不变：失败时仍为 None（no-op），不破坏现有 pipeline
- 添加模块级 logger（agent_pipeline.py 顶部）

### D. DOI PENDING 占位符处理
- README badge：从无效的 zenodo.org/PENDING 链接改为 shields.io 橙色 PENDING badge
- bibtex entry：明确注释说明 PENDING 状态 + 如何获取真实 DOI
- CITATION.cff：43→44 MCP、45→44 期刊模板（与代码一致）

### E. ARCHITECTURE.md 检查
- Tier 3 描述实际已经清晰（"not wired into AgentOrchestrator" 在代码注释和文档中明确）
- 报告混淆了 README 数据源 Tier 和 ARCHITECTURE orchestrator Tier
- 无需修改

报告本身多处不实指控（已核实）：
- 2136 测试是夸大：pytest 实际收集 2136 个
- agents.yaml: 70 Journal Templates：agents.yaml 中无此声明
- Tier 1 CSMAR/Wind 不存在：user-csmar / user-wind MCP 真实存在
