### PR TITLE
fix(econometrics): handle empty lstsq residuals array in sargan_test

### DIFF
--- a/scripts/core/econometrics_rules.py
+++ b/scripts/core/econometrics_rules.py
@@ -474,8 +474,10 @@ class WeakInstrumentTest:
         try:
             # 残差对Z回归（含常数）求R²
             Z_with_const = np.column_stack([np.ones(n), Z_arr])
-            _, ssr_full, _ = np.linalg.lstsq(Z_with_const, residuals, rcond=None)[:3]
-            tss = np.sum((residuals - np.mean(residuals))**2)
+            lstsq_result = np.linalg.lstsq(Z_with_const, residuals, rcond=None)
+            # lstsq returns (x, residuals, rank, s); residuals may be empty if rank is full
+            ssr_full = float(lstsq_result[1].sum()) if len(lstsq_result[1]) > 0 else 0.0
+            tss = float(np.sum((residuals - np.mean(residuals))**2))
             r_sq = 1 - ssr_full / tss if tss > 0 else 0.0
         except np.linalg.LinAlgError:
             return {

--- a/scripts/core/econometrics_rules.py
+++ b/scripts/core/econometrics_rules.py
@@ -1066,9 +1066,10 @@ class HeteroskedasticityTest:
             X_vif = np.column_stack([np.ones(len(y_vif)), X_vif])
 
             try:
-                beta, ssr, rank = np.linalg.lstsq(X_vif, y_vif, rcond=None)[:3]
-                y_vif - X_vif @ beta
-                tss = np.sum((y_vif - np.mean(y_vif))**2)
+                lstsq_vif = np.linalg.lstsq(X_vif, y_vif, rcond=None)
+                ssr = float(lstsq_vif[1].sum()) if len(lstsq_vif[1]) > 0 else 0.0
+                y_vif - X_vif @ lstsq_vif[0]
+                tss = float(np.sum((y_vif - np.mean(y_vif))**2))
                 r2 = 1 - ssr / tss if tss > 0 else 0.0
                 vif = 1 / (1 - r2) if r2 < 1 else float("inf")
             except np.linalg.LinAlgError:


### PR DESCRIPTION
## Problem
np.linalg.lstsq() returns an empty residuals array when Z has full column rank.
Slicing it directly raised `TypeError: only 0-dimensional arrays can be converted to Python scalars`.

## Fix
Explicitly check `len()` and convert to float:

```python
ssr_full = float(lstsq_result[1].sum()) if len(lstsq_result[1]) > 0 else 0.0
tss = float(np.sum((residuals - np.mean(residuals))**2))
```

Caught by `test_sargan_exactly_identified`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)