### PR TITLE
ci: upgrade pinned CodeQL action to v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,9 +22,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@a2983b8bed1923f44751c5c43237f479442827b3 # v3
+        uses: github/codeql-action/init@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         with:
           languages: python
 
       - name: Analyze
-        uses: github/codeql-action/analyze@a2983b8bed1923f44751c5c43237f479442827b3 # v3
+        uses: github/codeql-action/analyze@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5


### PR DESCRIPTION
## Summary
- upgrade CodeQL init/analyze from v3 to v4.37.5
- pin both steps to the verified upstream commit `d1ba80a13dd99fba24a470575428917156a28b43`
- clear the announced v3/Node 20 deprecation warning observed in the audit remediation merge run

## Verification
- workflow YAML parses successfully
- audit remediation integrity tests: 6 passed
- upstream commit signature verified through the GitHub API