### PR TITLE
fix: harden mock authorization and standalone checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
         run: python3 scripts/ci_security_gate.py
         continue-on-error: false
 
-  # ── audit-2026-07-04 PR-2: unify 3 test batches into 1 job + xdist ────
+  # ── audit-2026-07-04 PR-2: unified test job + xdist ────────────────
   # P0-6 (3-batch fragile combine) + P0-7 (--maxfail truncation was in each
   # batch) + P0-8 (320 lines of fail-log-handler YAML duplicated). All
   # consolidated here; reusable fail handler in .github/actions/handle-fail/.
@@ -318,9 +318,8 @@ jobs:
           echo "::warning::Skipping coverage upload because test did not succeed:"
           echo "  test: ${{ needs.test.result }}"
 
-      # Explicit per-artifact download (avoids pattern-glob issues in PR runs).
-      # Download each batch only if that batch succeeded; combine whatever is available.
-      # This fixes the prior overly-strict condition requiring ALL 3 batches to succeed.
+      # Download the single unified test artifact explicitly; coverage is only
+      # meaningful when the complete test job succeeded.
       - name: Download coverage-unified
         if: needs.test.result == 'success'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![GitHub release](https://img.shields.io/github/v/release/csmar432/finai-research?color=blue)](https://github.com/csmar432/finai-research/releases)
 [![arXiv](https://img.shields.io/badge/arXiv-cs.AI-b31b1b.svg)](https://arxiv.org/)
 [![CI](https://img.shields.io/github/actions/workflow/status/csmar432/finai-research/ci.yml?branch=main&label=CI)](https://github.com/csmar432/finai-research/actions)
-[![Coverage](https://img.shields.io/badge/coverage-49.72%25-brightgreen)](https://codecov.io/gh/csmar432/finai-research)
+[![Coverage](https://img.shields.io/badge/coverage-58.3%25-brightgreen)](https://codecov.io/gh/csmar432/finai-research)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21262689.svg)](https://doi.org/10.5281/zenodo.21262689)
 [![Discussions](https://img.shields.io/github/discussions/csmar432/finai-research?color=blueviolet)](https://github.com/csmar432/finai-research/discussions)
 [![Open in GitHub Codespaces](https://img.shields.io/badge/Open%20in%20Codespaces-526ADF?logo=github)](https://codespaces.new/csmar432/finai-research)
@@ -708,4 +708,3 @@ If you use FinAI Research Workflow in published research, please cite it as:
 
 
 MIT License — see [LICENSE](LICENSE) for the full text.
-

--- a/docs/REMEDIATION_2026-08-03.md
+++ b/docs/REMEDIATION_2026-08-03.md
@@ -14,7 +14,7 @@ recommendations that would be unsafe or misleading to apply mechanically.
 | P1-2 security gate fail-open | Missing tools, malformed/empty output, unknown vulnerability severity, and scanner errors now block. Full locked dependencies and all `scripts/` + `mcp_servers/` are scanned. CodeQL was added. |
 | P1-4 Actions supply chain | Every third-party Action is pinned to a full commit SHA. Two nonexistent Sigstore Actions were replaced by the official Cosign installer with GitHub OIDC signing and immediate verification. |
 | P1-5 dependency SSOT | CI uses `requirements-ci-lock.txt`; constraints match the package bounds. Runtime test dependencies moved to `dev`; four confirmed-unused full-install dependencies were removed. `pandasql` was retained because an MCP server imports it. |
-| P1-6 coverage gate | A clean full run measured 58.2%; the aggregate gate was raised from 28% to 55%, retaining a small cross-platform margin toward 60%. Critical remediation paths have dedicated regression tests. |
+| P1-6 coverage gate | A clean full run measured 58.3%; the aggregate gate was raised from 28% to 55%, retaining a small cross-platform margin toward 60%. Critical remediation paths have dedicated regression tests. |
 | P2-1 environment reproducibility | Validation used fresh environments created from universal locks, without modifying the maintainer's existing virtual environment. Python 3.10 and 3.13 boundary installs and smoke tests passed; BLAS threads are bounded in CI to prevent xdist oversubscription. |
 | P2-2/P2-3 policy/version drift | Security support and scanner documentation were corrected; the release version and user-facing references now use canonical PEP 440 `0.2.0a0`. |
 | P2-5 confirmed static security findings | Bandit's four HIGH findings were remediated; the complete scan now reports zero HIGH/CRITICAL findings. |
@@ -39,8 +39,9 @@ recommendations that would be unsafe or misleading to apply mechanically.
 
 ## Verification evidence
 
-- Full clean-environment suite: 12,863 passed, 156 skipped, 88 xfailed,
-  3 xpassed; 58.2% branch coverage.
+- Follow-up clean-environment suite: 12,871 passed, 157 skipped, 83 xfailed,
+  3 xpassed; 58.3% branch coverage. The follow-up also adds exact-word
+  mock approval checks and covers all 17 guarded servers.
 - The 10 tests that timed out under unconstrained parallel BLAS all passed in a
   single-thread rerun; the final CI-equivalent run passed with bounded BLAS.
 - `audit_guard.py`: 25/25 checks passed.

--- a/mcp_servers/mcp_mock_helper.py
+++ b/mcp_servers/mcp_mock_helper.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 from pathlib import Path
 from typing import Any, Optional
@@ -110,7 +111,20 @@ def check_mock_permission(
     # 检查请求上下文是否含批准关键词
     ctx = request_context or ""
     ctx_lower = ctx.lower()
-    approved = any(kw in ctx_lower for kw in APPROVAL_KEYWORDS)
+    # Match Chinese approval phrases as phrases, but require whole English
+    # words. Otherwise text such as "yesterday" satisfies the one-letter
+    # approval token "y" and silently authorizes mock data.
+    chinese_approved = any(
+        kw in ctx_lower
+        for kw in APPROVAL_KEYWORDS
+        if any("\u4e00" <= ch <= "\u9fff" for ch in kw)
+    )
+    english_approved = any(
+        re.search(rf"(?<![a-z]){re.escape(kw)}(?![a-z])", ctx_lower)
+        for kw in APPROVAL_KEYWORDS
+        if kw.isascii()
+    )
+    approved = chinese_approved or english_approved
 
     if approved:
         return None  # 通过

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -456,12 +456,11 @@ filterwarnings = [
 ]
 # Minimum coverage to pass CI
 # Set lower than production target to allow incremental improvement
-# 目标是 80%, 当前 CI 阈值 25% (在 ci.yml 中)
+# 目标是 80%, 当前 CI 阈值 55% (在 ci.yml 中；达到 60% 后再提升)
 minversion = "7.0"
 
 # ── Coverage configuration ─────────────────────────────────────────────
-# 在 CI 中, 3 个 test batch 各自上传 .coverage 文件,
-# 由 coverage job 用 `coverage combine` 合并后上报 Codecov.
+# CI 的统一测试 job 生成 .coverage 文件，由 coverage job 校验并上报 Codecov。
 [tool.coverage.run]
 branch = true
 source = ["scripts"]

--- a/scripts/PROJECT_NUMBERS.json
+++ b/scripts/PROJECT_NUMBERS.json
@@ -106,7 +106,7 @@
   },
   "testing": {
     "test_files": 659,
-    "test_functions": 12687,
+    "test_functions": 12688,
     "numerical_correctness_tests": 9,
     "ci_coverage_gate": 55,
     "ci_coverage_target": 60,

--- a/scripts/audit_guard.py
+++ b/scripts/audit_guard.py
@@ -508,12 +508,9 @@ def check_12_fail_under_floor() -> CheckResult:
     """Audit claim (audit-2026-07-04 P0-1): 'fail-under is repeatedly lowered
     (6 -> 3 -> 15 -> 25)'.
 
-    Defense: enforce a minimum floor on fail-under. The floor is
-    intentionally conservative (=25) at PR-1 time because removing the
-    9 "CI not-imported" omit entries drops the apparent coverage from
-    a padded 25-30% to a real 26-27%. PR-6 will add ~425 real tests to
-    push coverage naturally above 30%, at which point this check's
-    floor should be raised in lockstep.
+    Defense: enforce the current CI floor (55%) so a future edit cannot
+    silently lower the coverage gate. Raise this constant with the workflow
+    when the measured coverage reaches the next milestone.
 
     Audit guard against silent threshold drift downward.
     """
@@ -524,25 +521,25 @@ def check_12_fail_under_floor() -> CheckResult:
     import re
     matches = re.findall(r"fail[-_]under=(\d+)", text)
     if not matches:
-        return CheckResult(False, "no fail-under directive", ">=25", [])
+        return CheckResult(False, "no fail-under directive", ">=55", [])
     vals = [int(x) for x in matches]
     min_v = min(vals)
     evidence = [
         f"  fail-under values found: {vals}",
         f"  minimum: {min_v}",
-        f"  audit-2026-07-04 floor: 25 (PR-1) -> 28 (PR-6 import smoke); 60% deferred to PR-8",
+        "  required floor: 55% (current CI gate; next milestone: 60%)",
     ]
-    if min_v >= 28:
+    if min_v >= 55:
         return CheckResult(
             passed=True,
             actual=f"min={min_v}",
-            expected=">=28 (audit-2026-07-04 floor at PR-6)",
+            expected=">=55 (current CI gate)",
             evidence=evidence,
         )
     return CheckResult(
         passed=False,
         actual=f"min={min_v}",
-        expected=">=28",
+        expected=">=55",
         evidence=evidence,
     )
 
@@ -1703,7 +1700,7 @@ CHECKS: list[AuditCheck] = [
     AuditCheck(
         12,
         "CI fail-under floor",
-        "Defense vs. audit-2026-07-04 P0-1 'lower threshold to pass' (floor=28 at PR-6; 60% deferred to PR-8)",
+        "Defense vs. audit-2026-07-04 P0-1 'lower threshold to pass' (floor=55; next milestone 60%)",
         check_12_fail_under_floor,
     ),
     AuditCheck(

--- a/scripts/count_assets.py
+++ b/scripts/count_assets.py
@@ -28,6 +28,12 @@ from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
+# Keep the documented ``python scripts/count_assets.py`` entry point
+# independent of the caller's PYTHONPATH.  When Python executes a file by
+# path it puts ``scripts/`` (not the repository root) on sys.path.
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
 
 def count_mcp_servers() -> dict[str, int]:
     """统计 MCP server 目录数 + server.py 状态。

--- a/tests/test_audit_guard.py
+++ b/tests/test_audit_guard.py
@@ -90,34 +90,24 @@ class TestAuditFunctions:
         )
 
     def test_check_10_llm_reviewer_stable_model(self):
-        # audit-2026-07-21: try/except/Exception:pass converted to xfail
-        pytest.xfail(
-            reason="no real assertion",
-        )
+        result = ag.check_10_llm_reviewer_stable_model()
+        assert result.passed, result.evidence
 
     def test_check_11_omit_longtail_not_growing(self):
-        # audit-2026-07-21: try/except/Exception:pass converted to xfail
-        pytest.xfail(
-            reason="no real assertion",
-        )
+        result = ag.check_11_omit_longtail_not_growing()
+        assert result.passed, result.evidence
 
     def test_check_12_fail_under_floor(self):
-        # audit-2026-07-21: try/except/Exception:pass converted to xfail
-        pytest.xfail(
-            reason="no real assertion",
-        )
+        result = ag.check_12_fail_under_floor()
+        assert result.passed, result.evidence
 
     def test_check_13_workflow_yaml_unquoted_colons(self):
-        # audit-2026-07-21: try/except/Exception:pass converted to xfail
-        pytest.xfail(
-            reason="no real assertion",
-        )
+        result = ag.check_13_workflow_yaml_unquoted_colons()
+        assert result.passed, result.evidence
 
     def test_check_14_diff_in_diff2_phantom_dep(self):
-        # audit-2026-07-21: try/except/Exception:pass converted to xfail
-        pytest.xfail(
-            reason="no real assertion",
-        )
+        result = ag.check_14_diff_in_diff2_phantom_dep()
+        assert result.passed, result.evidence
 
     def test_check_15_pypi_deps_exist(self):
         # audit-2026-07-21: this test serial-visits PyPI 30 times.

--- a/tests/test_mock_data_default_disabled.py
+++ b/tests/test_mock_data_default_disabled.py
@@ -1,7 +1,4 @@
-"""Mock 数据默认禁用测试。
-
-回归测试：确保以下 5 个 mock 服务器默认模式下调用被拒绝。
-"""
+"""Mock 数据默认禁用与确认边界测试。"""
 
 from __future__ import annotations
 
@@ -15,7 +12,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 
-# 受 mock 拦截保护的 5 个服务器
+# 代表性 mock 服务器；全量守卫数量由 test_default_mode_blocks_all_guarded_servers 校验
 PROTECTED_SERVERS = [
     ("user_nber_wp", "handle_search"),
     ("user_bea_data", "handle_gdp"),
@@ -71,9 +68,21 @@ def test_confirm_mode_works_as_before():
     assert result is None, "confirm 模式含批准词应通过"
 
 
+@pytest.mark.parametrize("context", ["yesterday", "okayish", "confirmation pending"])
+def test_confirm_mode_does_not_accept_approval_substrings(context):
+    """Unrelated English words must not authorize mock data."""
+    from mcp_servers.mcp_mock_helper import check_mock_permission
+
+    os.environ["MCP_MOCK_MODE"] = "confirm"
+    result = check_mock_permission(
+        {}, "handle_search", "user-nber-wp", request_context=context
+    )
+    assert result is not None, f"{context!r} must not authorize mock data"
+
+
 @pytest.mark.parametrize("server_name,tool_name", PROTECTED_SERVERS)
-def test_all_5_mock_servers_protected(server_name, tool_name):
-    """所有 5 个 mock server 的 handler 必须调用 check_mock_permission。
+def test_representative_mock_servers_protected(server_name, tool_name):
+    """代表性 mock server 必须调用 check_mock_permission。
 
     防止未来回归：有人删除 mock 拦截。
     """
@@ -117,11 +126,19 @@ def test_macro_datas_handlers_all_protected():
     assert checks >= 5, f"应至少 5 次 check_mock_permission 调用，实际 {checks}"
 
 
-def test_default_mode_blocks_all_5_servers():
-    """默认模式下调用 5 个 server 的任意 handler 都会被拦截。"""
+def test_default_mode_blocks_all_guarded_servers():
+    """默认模式下所有接入统一守卫的 server 都会被拦截。"""
     from mcp_servers.mcp_mock_helper import check_mock_permission
 
-    for server_name, tool_name in PROTECTED_SERVERS:
+    protected = []
+    for server_py in sorted(Path("mcp_servers").glob("user_*/server.py")):
+        text = server_py.read_text()
+        if "check_mock_permission" not in text:
+            continue
+        protected.append((server_py.parent.name, "regression_probe"))
+
+    assert len(protected) >= 17, f"expected at least 17 guarded servers, found {len(protected)}"
+    for server_name, tool_name in protected:
         result = check_mock_permission({}, tool_name, server_name.replace("_", "-"))
         assert result is not None, (
             f"{server_name}.{tool_name} 默认模式应被拦截，但通过了"


### PR DESCRIPTION
## Summary
- require whole-word English approval tokens for mock data
- regression-test all 17 guarded MCP servers
- make count_assets.py runnable without PYTHONPATH
- synchronize the coverage floor and current metrics in guard/docs

## Verification
- 12,871 passed, 157 skipped, 83 xfailed, 3 xpassed
- 58.3% branch coverage; CI gate 55%
- Ruff, YAML/TOML parsing, audit_guard checks 12/13/14 passed
- standalone count_assets entrypoint passed

The existing untracked .png file was not modified.