### PR TITLE
ci: enforce 75 percent critical research coverage

### DIFF
--- a/.github/coverage-critical-paths.txt
+++ b/.github/coverage-critical-paths.txt
@@ -1,0 +1,16 @@
+# Critical, independently testable research-integrity and econometrics paths.
+# Keep this list explicit: adding a module is a coverage commitment, not a
+# denominator shortcut.
+scripts/core/provenance.py
+scripts/core/data_warning_notifier.py
+scripts/core/hitl_gate.py
+scripts/research_framework/regression_engine.py
+scripts/research_framework/data_validator.py
+scripts/research_framework/reference_validator.py
+scripts/research_framework/rdd.py
+scripts/research_framework/psm_did.py
+scripts/research_framework/synthetic_control.py
+scripts/research_framework/synthetic_did.py
+scripts/research_framework/spatial_regression.py
+scripts/research_framework/survival_analysis.py
+scripts/research_framework/volatility_models.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,6 +344,13 @@ jobs:
           coverage combine --keep coverage-data/unified/.coverage
           # Coverage is a required quality gate, not an optional report.
           coverage report -m --fail-under=55
+      - name: Critical research path coverage (>=75%)
+        if: needs.test.result == 'success'
+        run: |
+          set -euo pipefail
+          include=$(grep -v '^#' .github/coverage-critical-paths.txt | paste -sd, -)
+          test -n "$include"
+          coverage report -m --include="$include" --fail-under=75
       - name: Upload to Codecov
         if: needs.test.result == 'success'
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4

--- a/docs/REMEDIATION_2026-08-03.md
+++ b/docs/REMEDIATION_2026-08-03.md
@@ -42,6 +42,9 @@ recommendations that would be unsafe or misleading to apply mechanically.
 - Follow-up clean-environment suite: 12,871 passed, 157 skipped, 83 xfailed,
   3 xpassed; 58.3% branch coverage. The follow-up also adds exact-word
   mock approval checks and covers all 17 guarded servers.
+- The CI coverage job now separately enforces >=75% on an explicit critical
+  research-path list (current local branch coverage: 87.4%); the aggregate
+  repository metric remains visible and is not artificially narrowed.
 - The 10 tests that timed out under unconstrained parallel BLAS all passed in a
   single-thread rerun; the final CI-equivalent run passed with bounded BLAS.
 - `audit_guard.py`: 25/25 checks passed.


### PR DESCRIPTION
## Summary
- add an explicit critical research-path coverage scope
- enforce >=75% branch coverage for that scope in the CI coverage job
- keep the full-repository aggregate report and 55% gate unchanged

## Verification
- critical scope: 87.4% branch coverage (6,000 statements, 1,570 branches)
- full repository: 58.3% branch coverage
- YAML parse and git diff checks passed

This is an explicit quality scope, not an omit-list change or denominator rewrite.