### PR TITLE
test: raise aggregate branch coverage gate to 60%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,14 +343,14 @@ jobs:
           test -s "coverage-data/unified/.coverage"
           coverage combine --keep coverage-data/unified/.coverage
           # Coverage is a required quality gate, not an optional report.
-          coverage report -m --fail-under=55
-      - name: Critical research path coverage (>=75%)
+          coverage report -m --fail-under=60
+      - name: Critical research path coverage (>=80%)
         if: needs.test.result == 'success'
         run: |
           set -euo pipefail
           include=$(grep -v '^#' .github/coverage-critical-paths.txt | paste -sd, -)
           test -n "$include"
-          coverage report -m --include="$include" --fail-under=75
+          coverage report -m --include="$include" --fail-under=80
       - name: Upload to Codecov
         if: needs.test.result == 'success'
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![GitHub release](https://img.shields.io/github/v/release/csmar432/finai-research?color=blue)](https://github.com/csmar432/finai-research/releases)
 [![arXiv](https://img.shields.io/badge/arXiv-cs.AI-b31b1b.svg)](https://arxiv.org/)
 [![CI](https://img.shields.io/github/actions/workflow/status/csmar432/finai-research/ci.yml?branch=main&label=CI)](https://github.com/csmar432/finai-research/actions)
-[![Coverage](https://img.shields.io/badge/coverage-58.3%25-brightgreen)](https://codecov.io/gh/csmar432/finai-research)
+[![Coverage](https://img.shields.io/badge/coverage-60.0%25-brightgreen)](https://codecov.io/gh/csmar432/finai-research)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21262689.svg)](https://doi.org/10.5281/zenodo.21262689)
 [![Discussions](https://img.shields.io/github/discussions/csmar432/finai-research?color=blueviolet)](https://github.com/csmar432/finai-research/discussions)
 [![Open in GitHub Codespaces](https://img.shields.io/badge/Open%20in%20Codespaces-526ADF?logo=github)](https://codespaces.new/csmar432/finai-research)

--- a/docs/REMEDIATION_2026-08-03.md
+++ b/docs/REMEDIATION_2026-08-03.md
@@ -14,7 +14,7 @@ recommendations that would be unsafe or misleading to apply mechanically.
 | P1-2 security gate fail-open | Missing tools, malformed/empty output, unknown vulnerability severity, and scanner errors now block. Full locked dependencies and all `scripts/` + `mcp_servers/` are scanned. CodeQL was added. |
 | P1-4 Actions supply chain | Every third-party Action is pinned to a full commit SHA. Two nonexistent Sigstore Actions were replaced by the official Cosign installer with GitHub OIDC signing and immediate verification. |
 | P1-5 dependency SSOT | CI uses `requirements-ci-lock.txt`; constraints match the package bounds. Runtime test dependencies moved to `dev`; four confirmed-unused full-install dependencies were removed. `pandasql` was retained because an MCP server imports it. |
-| P1-6 coverage gate | A clean full run measured 58.3%; the aggregate gate was raised from 28% to 55%, retaining a small cross-platform margin toward 60%. Critical remediation paths have dedicated regression tests. |
+| P1-6 coverage gate | A clean full run measured 60.0%; the aggregate gate was raised from 55% to 60%, while the critical research-path gate is 80%. The next aggregate milestone is 65%. |
 | P2-1 environment reproducibility | Validation used fresh environments created from universal locks, without modifying the maintainer's existing virtual environment. Python 3.10 and 3.13 boundary installs and smoke tests passed; BLAS threads are bounded in CI to prevent xdist oversubscription. |
 | P2-2/P2-3 policy/version drift | Security support and scanner documentation were corrected; the release version and user-facing references now use canonical PEP 440 `0.2.0a0`. |
 | P2-5 confirmed static security findings | Bandit's four HIGH findings were remediated; the complete scan now reports zero HIGH/CRITICAL findings. |
@@ -39,10 +39,10 @@ recommendations that would be unsafe or misleading to apply mechanically.
 
 ## Verification evidence
 
-- Follow-up clean-environment suite: 12,871 passed, 157 skipped, 83 xfailed,
-  3 xpassed; 58.3% branch coverage. The follow-up also adds exact-word
+- Follow-up clean-environment suite: 12,881 passed, 157 skipped, 82 xfailed,
+  3 xpassed; 60.0% branch coverage. The follow-up also adds exact-word
   mock approval checks and covers all 17 guarded servers.
-- The CI coverage job now separately enforces >=75% on an explicit critical
+- The CI coverage job now separately enforces >=80% on an explicit critical
   research-path list (current local branch coverage: 87.4%); the aggregate
   repository metric remains visible and is not artificially narrowed.
 - The 10 tests that timed out under unconstrained parallel BLAS all passed in a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -456,7 +456,7 @@ filterwarnings = [
 ]
 # Minimum coverage to pass CI
 # Set lower than production target to allow incremental improvement
-# 目标是 80%, 当前 CI 阈值 55% (在 ci.yml 中；达到 60% 后再提升)
+# 目标是 80%, 当前 CI 阈值 60% (在 ci.yml 中；达到 65% 后再提升)
 minversion = "7.0"
 
 # ── Coverage configuration ─────────────────────────────────────────────

--- a/scripts/SCRIPTS_INDEX.md
+++ b/scripts/SCRIPTS_INDEX.md
@@ -13,11 +13,11 @@
 | 📦 Core Modules (`scripts/core/`) | 105 | 核心库（被其他模块导入）|
 | 📊 Research Framework (`scripts/research_framework/`) | 59 | 计量方法模块 |
 | 🧭 Research Directions (`scripts/research_directions/`) | 15 | 研究方向领域 |
-| 🧪 Tests (`tests/`) | 661 | 测试文件 |
+| 🧪 Tests (`tests/`) | 666 | 测试文件 |
 | 🔌 MCP Servers (`mcp_servers/user_*/`) | 43 | MCP 数据源 |
-| **合计（仅 Python 文件）** | **945** | 不含 MCP / docs / tests fixtures |
+| **合计（仅 Python 文件）** | **950** | 不含 MCP / docs / tests fixtures |
 
-> 自动生成于 2026-08-03
+> 自动生成于 2026-08-04
 ---
 
 ## 一、Entry Points · 用户入口
@@ -218,4 +218,4 @@ report_*.py           # 报告生成（小写下划线）
 
 ---
 
-*本索引由 `scripts/SCRIPTS_INDEX.md` 维护，最后更新: 2026-08-03（自动对账）
+*本索引由 `scripts/SCRIPTS_INDEX.md` 维护，最后更新: 2026-08-04（自动对账）

--- a/scripts/audit_guard.py
+++ b/scripts/audit_guard.py
@@ -40,6 +40,11 @@ from typing import Callable
 
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
+# When invoked as ``python scripts/audit_guard.py``, Python puts ``scripts/``
+# ahead of the repository root.  Put the root first so package imports cannot
+# accidentally resolve sibling modules as top-level stdlib names.
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
 
 
 @dataclass
@@ -508,7 +513,7 @@ def check_12_fail_under_floor() -> CheckResult:
     """Audit claim (audit-2026-07-04 P0-1): 'fail-under is repeatedly lowered
     (6 -> 3 -> 15 -> 25)'.
 
-    Defense: enforce the current CI floor (55%) so a future edit cannot
+    Defense: enforce the current CI floor (60%) so a future edit cannot
     silently lower the coverage gate. Raise this constant with the workflow
     when the measured coverage reaches the next milestone.
 
@@ -521,25 +526,25 @@ def check_12_fail_under_floor() -> CheckResult:
     import re
     matches = re.findall(r"fail[-_]under=(\d+)", text)
     if not matches:
-        return CheckResult(False, "no fail-under directive", ">=55", [])
+        return CheckResult(False, "no fail-under directive", ">=60", [])
     vals = [int(x) for x in matches]
     min_v = min(vals)
     evidence = [
         f"  fail-under values found: {vals}",
         f"  minimum: {min_v}",
-        "  required floor: 55% (current CI gate; next milestone: 60%)",
+        "  required floor: 60% (current CI gate; next milestone: 65%)",
     ]
-    if min_v >= 55:
+    if min_v >= 60:
         return CheckResult(
             passed=True,
             actual=f"min={min_v}",
-            expected=">=55 (current CI gate)",
+            expected=">=60 (current CI gate)",
             evidence=evidence,
         )
     return CheckResult(
         passed=False,
         actual=f"min={min_v}",
-        expected=">=55",
+        expected=">=60",
         evidence=evidence,
     )
 
@@ -1700,7 +1705,7 @@ CHECKS: list[AuditCheck] = [
     AuditCheck(
         12,
         "CI fail-under floor",
-        "Defense vs. audit-2026-07-04 P0-1 'lower threshold to pass' (floor=55; next milestone 60%)",
+        "Defense vs. audit-2026-07-04 P0-1 'lower threshold to pass' (floor=60; next milestone 65%)",
         check_12_fail_under_floor,
     ),
     AuditCheck(

--- a/scripts/core/agents/paper_agents.py
+++ b/scripts/core/agents/paper_agents.py
@@ -11,7 +11,9 @@ Five professional agents following PaperOrchestra's design:
 from __future__ import annotations
 
 import json
+import os
 import logging
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any

--- a/scripts/core/tool_middleware.py
+++ b/scripts/core/tool_middleware.py
@@ -241,7 +241,10 @@ class ToolCallLogger:
 
     def _get_handle(self):
         """Get or create the daily log file handle."""
-        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        # File rotation follows the host's local calendar day, matching the
+        # documented filename contract and making daily logs predictable for
+        # operators.  Individual event timestamps remain UTC below.
+        today = datetime.now().strftime("%Y-%m-%d")
         if self._fh is None or self._day != today:
             if self._fh is not None:
                 try:

--- a/scripts/generate_national_excel.py
+++ b/scripts/generate_national_excel.py
@@ -117,6 +117,33 @@ def load_data() -> dict:
         return json.load(f)
 
 
+def ranking_record(row) -> dict:
+    """Normalize legacy list rows and current dict rows from ranking tables."""
+    if isinstance(row, dict):
+        return row
+    if isinstance(row, (list, tuple)):
+        values = list(row)
+        return {
+            "rank": values[0] if len(values) > 0 else "—",
+            "province": values[1] if len(values) > 1 else "—",
+            "value": values[2] if len(values) > 2 else "—",
+            "note": values[3] if len(values) > 3 else "",
+        }
+    return {"rank": "—", "province": "—", "value": "—", "note": ""}
+
+
+def series_values(province: dict, name: str) -> dict:
+    """Return a time-series mapping across legacy and current data shapes."""
+    raw = province.get("time_series", {})
+    if not isinstance(raw, dict):
+        return {}
+    series = raw.get(name, {})
+    if isinstance(series, dict):
+        values = series.get("data", series)
+        return values if isinstance(values, dict) else {}
+    return {}
+
+
 # ── Sheet 1: 数据总览 ─────────────────────────────────────────────────────────
 
 def sheet_overview(wb, national):
@@ -203,7 +230,8 @@ def sheet_overview(wb, national):
     for table_id, tdata in rankings.items():
         rows_data = tdata.get("data", [])
         cells = [tdata.get("title", table_id)]
-        for r in rows_data[:5]:
+        for raw_row in rows_data[:5]:
+            r = ranking_record(raw_row)
             cells.append(f"{r['province']} {r['value']}")
         for col, val in enumerate(cells, 1):
             data_cell(ws, row, col, val, bold=(col == 1))
@@ -220,7 +248,8 @@ def sheet_gdp(wb, national):
     set_col_width(ws, [(1, 8), (2, 12), (3, 16), (4, 12), (5, 30)])
 
     gdpr = national["ranking_tables"]["GDP_2024"]["data"]
-    for i, r in enumerate(gdpr):
+    for i, raw_row in enumerate(gdpr):
+        r = ranking_record(raw_row)
         fill = "E2EFDA" if i == 0 else ("DEEAF1" if i < 3 else "")
         data_cell(ws, 3 + i, 1, r["rank"], fill_hex=fill, bold=True, align="center")
         data_cell(ws, 3 + i, 2, r["province"], fill_hex=fill, bold=(i == 0))
@@ -235,7 +264,7 @@ def sheet_gdp(wb, national):
     hdr_row(ws, row, ["年份", "GDP(亿元)", "同比增速(%)", "说明"], "375623")
     set_col_width(ws, [(1, 10), (2, 16), (3, 14), (4, 30)])
 
-    hubei_ts = national["provinces"]["湖北"]["time_series"]["GDP"]["data"]
+    hubei_ts = series_values(national["provinces"]["湖北"], "GDP")
     years = sorted(hubei_ts.keys(), key=lambda y: int(y))
     prev = None
     for i, y in enumerate(years):
@@ -265,7 +294,7 @@ def sheet_gdp(wb, national):
     lookup = {}
     for prov_name in ["广东", "江苏", "浙江", "山东", "湖北"]:
         prov = national["provinces"].get(prov_name, {})
-        ts = prov.get("time_series", {}).get("GDP", {}).get("data", {})
+        ts = series_values(prov, "GDP")
         lookup[prov_name] = ts
 
     cross_row = row + 1
@@ -291,7 +320,8 @@ def sheet_rd(wb, national):
 
     # R&D经费排名
     rd_rank = national["ranking_tables"].get("RD经费_2024", {}).get("data", [])
-    for i, r in enumerate(rd_rank):
+    for i, raw_row in enumerate(rd_rank):
+        r = ranking_record(raw_row)
         fill = "E2EFDA" if i == 0 else ("FFF2CC" if i < 3 else "")
         data_cell(ws, 3 + i, 1, r["rank"], fill_hex=fill, bold=True, align="center")
         data_cell(ws, 3 + i, 2, r["province"], fill_hex=fill, bold=(i == 0))
@@ -306,7 +336,8 @@ def sheet_rd(wb, national):
     hdr_row(ws, row, ["排名", "省份", "R&D强度(%)", "超过全国均值(2.69%)", "说明"], "375623")
 
     rd_int = national["ranking_tables"].get("RD强度_2024", {}).get("data", [])
-    for i, r in enumerate(rd_int):
+    for i, raw_row in enumerate(rd_int):
+        r = ranking_record(raw_row)
         fill = "E2EFDA" if r["value"] > 3 else ""
         note = r.get("note", "")
         data_cell(ws, row + 1 + i, 1, r["rank"], fill_hex=fill, bold=True, align="center")
@@ -321,7 +352,7 @@ def sheet_rd(wb, national):
     row += 1
     hdr_row(ws, row, ["年份", "R&D经费(亿元)", "同比增速(%)", "说明"], "404040")
 
-    hubei_ts = national["provinces"]["湖北"]["time_series"]["R&D经费"]["data"]
+    hubei_ts = series_values(national["provinces"]["湖北"], "R&D经费")
     years = sorted(hubei_ts.keys(), key=lambda y: int(y))
     prev = None
     for i, y in enumerate(years):
@@ -345,7 +376,8 @@ def sheet_tech_ent(wb, national):
     set_col_width(ws, [(1, 8), (2, 12), (3, 18), (4, 28), (5, 20)])
 
     ent_rank = national["ranking_tables"].get("高新技术企业_2024", {}).get("data", [])
-    for i, r in enumerate(ent_rank):
+    for i, raw_row in enumerate(ent_rank):
+        r = ranking_record(raw_row)
         fill = "E2EFDA" if i == 0 else ""
         data_cell(ws, 3 + i, 1, r["rank"], fill_hex=fill, bold=True, align="center")
         data_cell(ws, 3 + i, 2, r["province"], fill_hex=fill, bold=(i == 0))
@@ -364,7 +396,8 @@ def sheet_tech(wb, national):
     set_col_width(ws, [(1, 8), (2, 12), (3, 16), (4, 10), (5, 24)])
 
     tech_rank = national["ranking_tables"].get("技术合同_2024", {}).get("data", [])
-    for i, r in enumerate(tech_rank):
+    for i, raw_row in enumerate(tech_rank):
+        r = ranking_record(raw_row)
         fill = "E2EFDA" if i == 0 else ""
         data_cell(ws, 3 + i, 1, r["rank"], fill_hex=fill, bold=True, align="center")
         data_cell(ws, 3 + i, 2, r["province"], fill_hex=fill, bold=(i == 0))
@@ -378,7 +411,7 @@ def sheet_tech(wb, national):
     row += 1
     hdr_row(ws, row, ["年份", "成交额(亿元)", "同比增速(%)", "数据来源"], "375623")
 
-    hubei_ts = national["provinces"]["湖北"]["time_series"]["技术合同成交额"]["data"]
+    hubei_ts = series_values(national["provinces"]["湖北"], "技术合同成交额")
     years = sorted(hubei_ts.keys(), key=lambda y: int(y))
     prev = None
     for i, y in enumerate(years):
@@ -460,7 +493,7 @@ def sheet_edu(wb, national):
     row += 1
     hdr_row(ws, row, ["年份", "在校生(万人)", "同比增速(%)", "说明"], "375623")
 
-    hubei_ts = national["provinces"]["湖北"]["time_series"]["本专科在校生"]["data"]
+    hubei_ts = series_values(national["provinces"]["湖北"], "本专科在校生")
     years = sorted(hubei_ts.keys(), key=lambda y: int(y))
     prev = None
     for i, y in enumerate(years):
@@ -482,12 +515,14 @@ def sheet_hubei_ts(wb, national):
 
     hubei = national["provinces"]["湖北"]
     ts_map = hubei.get("time_series", {})
+    if not isinstance(ts_map, dict):
+        ts_map = {}
 
     row = 2
     for series_name, series_data in ts_map.items():
         unit = series_data.get("unit", "")
         source = series_data.get("source", "")
-        data = series_data.get("data", {})
+        data = series_data.get("data", {}) if isinstance(series_data, dict) else {}
 
         # Series header
         ws.merge_cells(start_row=row, start_column=1, end_row=row, end_column=8)
@@ -532,7 +567,7 @@ def sheet_quality(wb, national):
     hdr_row(ws, 2, ["省份", "核查状态", "GDP排名", "已收录类别数", "时间序列(条)", "说明"], "C00000")
     set_col_width(ws, [(1, 12), (2, 12), (3, 10), (4, 14), (5, 16), (6, 40)])
 
-    vs = national["verification_status"]
+    vs = national.get("verification_status", {})
     provinces = national["provinces"]
     row = 3
     for prov_name in sorted(provinces.keys(),
@@ -545,7 +580,11 @@ def sheet_quality(wb, national):
         cat_count = len(cats)
 
         fill = VERIF_COLORS.get(verif, "")
-        verif_label = {"full": "A类(已核查)", "partial": "B类(部分核查)", "minimal": "C类(最少)"}[verif]
+        verif_label = {
+            "full": "A类(已核查)",
+            "partial": "B类(部分核查)",
+            "minimal": "C类(最少)",
+        }.get(verif, "C类(最少)")
 
         note = ""
         if verif == "full":
@@ -577,6 +616,7 @@ def sheet_quality(wb, national):
     )
     total_ts = sum(
         sum(len(s.get("data", {})) for s in prov.get("time_series", {}).values())
+        if isinstance(prov.get("time_series", {}), dict) else 0
         for prov in provinces.values()
     )
     ranking_count = len(national.get("ranking_tables", {}))

--- a/scripts/paper_reader.py
+++ b/scripts/paper_reader.py
@@ -409,6 +409,9 @@ def compare_papers_with_ai(arxiv_ids: list[str], question: str) -> str:
     """对比多篇论文。"""
     sys.path.insert(0, str(SCRIPT_DIR))
     from scripts.ai_router import Task
+    from scripts.core.llm_gateway import LLMGateway
+
+    gateway = LLMGateway(memory=None, use_cache=True)
 
     papers_content = []
     for aid in arxiv_ids:

--- a/scripts/pipeline_builder.py
+++ b/scripts/pipeline_builder.py
@@ -141,7 +141,7 @@ def _step_id() -> str:
 
 def _build_pipeline_yaml() -> dict:
     """Build the YAML dict for the current pipeline."""
-    st.session_state.pb_pipeline_name.strip() or "my_pipeline"
+    name = st.session_state.pb_pipeline_name.strip() or "my_pipeline"
     desc = st.session_state.pb_pipeline_desc.strip() or "自定义流水线"
 
     steps_yaml = []
@@ -159,7 +159,7 @@ def _build_pipeline_yaml() -> dict:
         steps_yaml.append(entry)
 
     return {
-        "name": desc,
+        "name": name,
         "description": desc,
         "mode": "sequential",
         "steps": steps_yaml,

--- a/tests/test_core_paper_agents_coverage.py
+++ b/tests/test_core_paper_agents_coverage.py
@@ -1,0 +1,174 @@
+"""Behavior coverage for the three deterministic paper-agent paths."""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from types import SimpleNamespace
+
+from scripts.core.agents import paper_agents as pa
+from scripts.core.agents.base import AgentCancelledError, BaseAgent, CancellationToken, HaltDecision
+
+
+class Gateway:
+    def __init__(self, response):
+        self.response = response
+        self.prompts = []
+
+    def register_agent(self, *_args):
+        return None
+
+    def generate(self, **kwargs):
+        self.prompts.append(kwargs["prompt"])
+        return SimpleNamespace(response=self.response, model_used="fake", latency_ms=1, tokens_used=2)
+
+
+def config(name):
+    return pa.AgentConfig(name=name, role="role", goal="goal", backstory="context", max_iterations=1)
+
+
+class DummyAgent(BaseAgent):
+    def __init__(self, mode="approve", **kwargs):
+        cfg = config("dummy")
+        cfg.max_iterations = 2
+        super().__init__(cfg, Gateway(""))
+        self.mode, self.calls = mode, 0
+
+    def act(self, context):
+        self.calls += 1
+        if self.mode == "error":
+            raise RuntimeError("act error")
+        return {"calls": self.calls, "tokens_used": 1}
+
+    def reflect(self, result):
+        if self.mode == "reject":
+            return {"halt": HaltDecision.REJECTED, "feedback": "reject"}
+        if self.mode == "revise" and self.calls == 1:
+            return {"halt": HaltDecision.REVISE, "feedback": "again"}
+        if self.mode == "reflect_error":
+            raise RuntimeError("reflect error")
+        return {"halt": HaltDecision.APPROVED, "feedback": "ok"}
+
+
+def test_base_agent_run_decisions_and_json_parser():
+    approved = DummyAgent().run({})
+    assert approved.status == "approved" and approved.tokens_used == 1
+    revised = DummyAgent("revise").run({})
+    assert revised.status == "approved" and revised.iterations == 2
+    rejected = DummyAgent("reject").run({})
+    assert rejected.status == "error"
+    failed = DummyAgent("error").run({})
+    assert failed.status == "approved" and "error" in failed.output
+    reflect_failed = DummyAgent("reflect_error").run({})
+    assert reflect_failed.status == "error"
+    cancelled = CancellationToken()
+    cancelled.cancel("stop")
+    try:
+        DummyAgent().run({}, cancel_token=cancelled)
+    except AgentCancelledError as exc:
+        assert "stop" in str(exc)
+    assert DummyAgent()._parse_json_response("```json\n{\"a\": 1}\n```") == {"a": 1}
+    assert DummyAgent()._parse_json_response("prefix [1, 2] suffix") == [1, 2]
+
+
+def test_outline_agent_act_and_reflect_branches():
+    outline = {"meta": {"contribution_statement": "new"},
+               "chapters": [{"chapter_id": i, "title": "Method"} for i in range(7)],
+               "figure_plan": [], "literature_plan": {}}
+    agent = pa.OutlineAgent(config("outline"), Gateway(json.dumps(outline)))
+    result = agent.act({"topic": "topic", "venue": "JF", "idea": "idea", "field": "finance"})
+    assert result["outline"] == outline
+    assert agent.reflect(result)["halt"] == pa.HaltDecision.APPROVED
+    assert agent.reflect({"outline": {"raw": True}})["flags"] == ["format_error"]
+    assert agent.reflect({"outline": {}})["flags"] == ["incomplete_structure"]
+    assert agent.reflect({"outline": {"meta": {}, "chapters": [], "figure_plan": [], "literature_plan": {}}})["flags"] == ["too_short"]
+
+
+def test_literature_agent_search_verify_and_graph(monkeypatch):
+    class Verifier:
+        def verify(self, candidate):
+            return {"verified": True, "source": "test", "levenshtein_score": .95, "abstract": "abs"}
+
+    agent = pa.LiteratureReviewAgent(config("literature"), Gateway("[]"), citation_verifier=Verifier())
+    agent._search_candidates = lambda query, limit: [{"title": "Paper", "authors": ["A"], "year": 2024,
+                                                       "doi": "10/x", "venue": "J"}]
+    result = agent.act({"search_queries": ["q"]})
+    assert result["coverage"] == 1 and result["coverage_stats"]["total"] == 1
+    assert result["citation_graph"]["total_papers"] == 1
+    assert agent.reflect(result)["halt"] == pa.HaltDecision.REVISE  # fewer than five
+    assert agent._parse_authors({"authors": "A, B"}) == ["A", "B"]
+    assert agent._parse_authors({"authors": [{"name": "A"}]}) == ["A"]
+    assert agent._parse_year({"published": "bad"}) == 2024
+    assert agent._build_citation_graph([])["total_papers"] == 0
+
+    class MCPResult:
+        def __init__(self, data):
+            self.success, self.data = True, data
+    fake_gateway_module = types.SimpleNamespace(
+        MCPResult=MCPResult,
+        call_mcp_tool=lambda *_args, **_kwargs: MCPResult([{
+            "title": "Found", "authors": [{"name": "A"}], "published": "2023-01-01",
+            "url": "u", "snippet": "J"
+        }]),
+    )
+    monkeypatch.setitem(sys.modules, "scripts.core.llm_gateway", fake_gateway_module)
+    agent._search_candidates = pa.LiteratureReviewAgent._search_candidates.__get__(agent)
+    candidates = agent._search_candidates("query", 2)
+    assert candidates[0]["title"] == "Found" and candidates[0]["year"] == 2023
+
+
+def test_section_writing_context_and_reflect():
+    text = "word " * 220
+    agent = pa.SectionWritingAgent(config("writing"), Gateway(text))
+    result = agent.act({"outline": {"chapters": [{"chapter_id": 1, "title": "Method",
+                                                     "summary": "s", "key_points": ["p"]}]},
+                        "citations": [{"authors": ["A"], "year": 2024, "title": "T", "verified": True}],
+                        "empirical_data": {"method": {"n": 1}}})
+    assert result["chapter_count"] == 1 and result["total_word_count"] >= 200
+    assert agent.reflect(result)["halt"] == pa.HaltDecision.APPROVED
+    assert agent.reflect({"chapters": []})["flags"] == ["empty_output"]
+    assert agent._build_citation_context([]).startswith("（暂无")
+    assert "A (2024)" in agent._build_citation_context([{"authors": ["A"], "year": 2024, "title": "T"}])
+    assert "暂无实证" in agent._build_empirical_context({}, {"title": "Method"})
+    all_titles = list(agent.CHAPTER_PROMPTS)
+    all_result = agent.act({"outline": {"chapters": [{"chapter_id": i, "title": title,
+                                                         "summary": "s", "key_points": []}
+                                                        for i, title in enumerate(all_titles)]}})
+    assert all_result["chapter_count"] == len(all_titles)
+
+
+def test_refinement_plotting_and_data_fetch_fallbacks(monkeypatch, tmp_path):
+    review = {"verdict": "approve", "violations": [], "overall_comments": "ok",
+              "scores": {"overall": 8}}
+    # Force the documented single-reviewer fallback without any external LLM.
+    class BrokenParliament:
+        def __init__(self, **_kwargs):
+            raise RuntimeError("unavailable")
+    monkeypatch.setitem(sys.modules, "scripts.core.ai_parliament", types.SimpleNamespace(AIParliament=BrokenParliament))
+    refinement = pa.ContentRefinementAgent(config("refine"), Gateway(json.dumps(review)))
+    result = refinement.act({"draft": "x" * 13000, "chapter": "Method"})
+    assert result["_audit"]["was_truncated"] is True
+    assert refinement.reflect(result)["halt"] == pa.HaltDecision.APPROVED
+    assert refinement.reflect({"review": {"verdict": "revise", "violations": [{"rule": "r", "issue": "i", "suggestion": "s"}], "scores": {"overall": 4}}})["halt"] == pa.HaltDecision.REVISE
+
+    plotting = pa.PlottingAgent(config("plot"), Gateway("print('CAPTION: c')"))
+    empty = plotting.act({"figure_plan": [], "output_dir": str(tmp_path)})
+    assert empty["total_figures"] == 0
+    assert plotting.reflect(empty)["flags"] == ["no_figures"]
+    assert plotting._execute_figure_code("f", "print(1)", str(tmp_path), {})["success"] is False
+    assert plotting._execute_figure_code("f", "", str(tmp_path), {})["error"] == "No code provided"
+    assert plotting._generate_figure_code("f", "desc", {}, {}) == "print('CAPTION: c')"
+    monkeypatch.setenv("FINAI_ALLOW_UNSAFE_DYNAMIC_TOOLS", "1")
+    executed = plotting._execute_figure_code("f", "print('SAVED_FILE: out.png')\nprint('CAPTION: cap')", str(tmp_path), {})
+    assert executed["success"] and executed["files"] == ["out.png"] and executed["caption"] == "cap"
+
+    class DataGateway(Gateway):
+        def call_mcp_tool(self, *_args):
+            return SimpleNamespace(success=True, data={"value": 1})
+    fetcher = pa.DataFetchAgent(config("data"), DataGateway(""))
+    fetched = fetcher.act({"provinces": ["湖北"], "indicators": ["GDP"], "years": ["2024"],
+                           "fetch_summary": True, "fetch_rankings": True})
+    assert fetched["summary"] == {"value": 1}
+    assert fetched["provinces"]["湖北"]["2024"]["GDP"] == {"value": 1}
+    assert set(fetched["rankings"]) == {"GDP_2024", "RD经费_2024", "高新技术企业_2024", "技术合同_2024"}

--- a/tests/test_generate_hubei_excel_v2_coverage.py
+++ b/tests/test_generate_hubei_excel_v2_coverage.py
@@ -1,0 +1,19 @@
+"""Exercise every deterministic sheet in the Hubei workbook generator."""
+
+from __future__ import annotations
+
+from openpyxl import load_workbook
+
+from scripts import generate_hubei_excel_v2 as mod
+
+
+def test_main_writes_nine_complete_sheets(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "data").mkdir()
+    mod.main()
+    output = tmp_path / "data" / "湖北省科技创新数据_2026_v2.xlsx"
+    assert output.exists() and output.stat().st_size > 10_000
+    wb = load_workbook(output, read_only=True)
+    assert wb.sheetnames == mod.TABS
+    assert wb[mod.TABS[0]]["A1"].value.startswith("湖北省科技创新")
+    assert "9 sheets" in capsys.readouterr().out

--- a/tests/test_generate_national_excel_coverage.py
+++ b/tests/test_generate_national_excel_coverage.py
@@ -1,0 +1,25 @@
+"""End-to-end coverage for the deterministic national workbook builder."""
+
+from __future__ import annotations
+
+from openpyxl import load_workbook
+
+from scripts import generate_national_excel as mod
+
+
+def test_main_builds_all_sheets_from_versioned_dataset(tmp_path, monkeypatch, capsys):
+    output = tmp_path / "national.xlsx"
+    monkeypatch.setattr(mod, "OUT_FILE", output)
+    # Use the checked-in dataset: this exercises the real formatting, ranking,
+    # time-series, verification, and source-tracking paths without network I/O.
+    mod.main()
+    assert output.exists() and output.stat().st_size > 10_000
+    wb = load_workbook(output, read_only=True)
+    assert wb.sheetnames == [
+        "1-数据总览", "2-GDP对比", "3-RD对比", "4-科技企业对比",
+        "5-技术转化对比", "6-新兴产业对比", "7-高校与人才",
+        "8-湖北时间序列", "9-数据质量报告",
+    ]
+    assert wb["1-数据总览"]["A1"].value.startswith("全国各省")
+    assert wb["9-数据质量报告"]["A1"].value.startswith("数据质量报告")
+    assert "9 sheets" in capsys.readouterr().out

--- a/tests/test_health_check_coverage.py
+++ b/tests/test_health_check_coverage.py
@@ -1,0 +1,129 @@
+"""Deterministic branch tests for health_check without external services."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from scripts import health_check as hc
+
+
+class Response:
+    status = 200
+
+    def __init__(self, body=b'{}'):
+        self.body = body
+
+    def read(self):
+        return self.body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+
+def test_env_mask_and_platform_detection(tmp_path, monkeypatch):
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "environment-key")
+    env_file = tmp_path / ".env"
+    env_file.write_text("# comment\nDEEPSEEK_API_KEY=file-key\nIGNORED=x=y\n", encoding="utf-8")
+    values = hc._read_env(env_file)
+    assert values["DEEPSEEK_API_KEY"] == "file-key"
+    assert hc._mask("1234567890") == "1234**7890"
+    assert hc._mask("short") == "*****"
+    monkeypatch.setenv("CURSOR", "cursor")
+    assert hc._detect_platform() == "cursor"
+    monkeypatch.delenv("CURSOR")
+    monkeypatch.setenv("CLAUDE_CODE", "claude_code")
+    assert hc._detect_platform() == "claude_code"
+    monkeypatch.delenv("CLAUDE_CODE")
+    monkeypatch.setenv("AGENT_ID", "codex-session")
+    assert hc._detect_platform() == "codex"
+
+
+@pytest.mark.parametrize("error, expected", [
+    (urllib.error.HTTPError("u", 401, "unauthorized", {}, None), (True, "HTTP 401")),
+    (urllib.error.HTTPError("u", 500, "server", {}, None), (False, "HTTP 500")),
+    (urllib.error.URLError("offline"), (False, "连接失败")),
+    (RuntimeError("boom"), (False, "boom")),
+])
+def test_probe_url_error_classes(monkeypatch, error, expected):
+    monkeypatch.setattr(hc.urllib.request, "urlopen", Mock(side_effect=error))
+    result = hc._probe_url("https://example.test")
+    assert result[0] is expected[0]
+    assert expected[1] in result[1]
+
+
+def test_llm_completion_success_json_and_failures(monkeypatch):
+    body = json.dumps({"choices": [{"message": {"content": "hello"}}]}).encode()
+    monkeypatch.setattr(hc.urllib.request, "urlopen", lambda *a, **k: Response(body))
+    ok, message = hc._llm_chat_completion("https://example.test", "key", "model")
+    assert ok and "response_len=5" in message
+
+    monkeypatch.setattr(hc.urllib.request, "urlopen", lambda *a, **k: Response(b"not-json"))
+    ok, message = hc._llm_chat_completion("https://example.test", "key", "model")
+    assert not ok and "JSON decode error" in message
+
+    error = urllib.error.HTTPError("u", 400, "bad", {}, None)
+    error.read = lambda: b'{"error":{"message":"invalid key"}}'
+    monkeypatch.setattr(hc.urllib.request, "urlopen", Mock(side_effect=error))
+    ok, message = hc._llm_chat_completion("https://example.test", "key", "model")
+    assert not ok and message == "invalid key"
+
+
+def test_check_dependencies_reports_import_error(monkeypatch):
+    real_import = hc.importlib.import_module
+
+    def fake_import(name):
+        if name in {"requests", "dotenv"}:
+            raise ImportError(name)
+        return real_import(name)
+
+    monkeypatch.setattr(hc.importlib, "import_module", fake_import)
+    problems, ok = hc._check_dependencies()
+    assert any(p.name == "requests" and p.severity == "high" for p in problems)
+    assert any(p.name == "dotenv" and p.severity == "medium" for p in problems)
+    assert any(item.startswith("numpy ") for item in ok)
+
+
+def test_platform_fixes_and_grouping():
+    assert "Cursor" in hc._platform_fixes("cursor")["restart_hint"] or "重启" in hc._platform_fixes("cursor")["restart_hint"]
+    assert "Claude" in hc._platform_fixes("claude_code")["restart_hint"]
+    assert "重新加载" in hc._platform_fixes("codex")["restart_hint"]
+    assert hc._platform_fixes("unknown")["env_hint"]
+    item = hc.ProblemItem(hc.ProblemCategory.NETWORK, "n", "N", "m", [])
+    groups = hc._group_by_category([item, item])
+    assert groups[hc.ProblemCategory.NETWORK] == [item, item]
+
+
+def test_verify_mcp_server_missing_and_popen_error(tmp_path, monkeypatch):
+    missing = hc._verify_mcp_server_stdio(tmp_path / "missing.py")
+    assert missing == (False, "server.py 不存在")
+    server = tmp_path / "server.py"
+    server.write_text("", encoding="utf-8")
+    monkeypatch.setattr(hc.subprocess, "Popen", Mock(side_effect=OSError("cannot spawn")))
+    ok, message = hc._verify_mcp_server_stdio(server)
+    assert not ok and message == "cannot spawn"
+
+
+def test_check_mcp_scans_local_servers_and_missing_keys(tmp_path, monkeypatch):
+    servers = tmp_path / "mcp_servers" / "user_tushare"
+    servers.mkdir(parents=True)
+    (servers / "server.py").write_text("", encoding="utf-8")
+    monkeypatch.setattr(hc, "_project_root", lambda: tmp_path)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path / "home"))
+    (tmp_path / "home").mkdir()
+    (tmp_path / "home" / ".cursor").mkdir()
+    (tmp_path / "home" / ".cursor" / "mcp.json").write_text(
+        json.dumps({"mcpServers": {"tushare": {}}}), encoding="utf-8"
+    )
+    enabled, verified, problems, ok = hc._check_mcp(verify=False)
+    assert enabled == 1 and verified == 0
+    assert any(p.name == "mcp_missing_api_keys" for p in problems)
+    assert ok == []

--- a/tests/test_health_check_mcp_coverage.py
+++ b/tests/test_health_check_mcp_coverage.py
@@ -1,0 +1,86 @@
+"""Deterministic coverage for MCP filesystem health reporting."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import pytest
+
+from scripts import health_check_mcp as mod
+
+
+def make_server(root, name, source="print('ok')", docker=False, metadata=False, tools=False):
+    path = root / name
+    path.mkdir()
+    (path / "server.py").write_text(source, encoding="utf-8")
+    if docker:
+        (path / "Dockerfile").write_text("FROM python:3.12", encoding="utf-8")
+    if metadata:
+        (path / "SERVER_METADATA.json").write_text("{}", encoding="utf-8")
+    if tools:
+        (path / "tools").mkdir()
+        (path / "tools" / "search.json").write_text("{}", encoding="utf-8")
+    return path
+
+
+def test_check_server_all_statuses_and_normalization(tmp_path):
+    missing = mod.check_server(tmp_path / "missing")
+    assert missing.status == "missing" and missing.error
+    no_py = tmp_path / "no_py"
+    no_py.mkdir()
+    assert mod.check_server(no_py).status == "incomplete"
+    no_docker = make_server(tmp_path, "no_docker")
+    result = mod.check_server(no_docker)
+    assert result.status == "compile_ok_no_docker" and result.compile_ok
+    ready = make_server(tmp_path, "ready", docker=True, metadata=True, tools=True)
+    result = mod.check_server(ready)
+    assert result.status == "ready" and result.tool_count == 1
+    broken = make_server(tmp_path, "broken", source="def broken(:\n")
+    result = mod.check_server(broken)
+    assert result.status == "compile_error" and result.compile_error
+    assert mod._normalize_name("User-East_Money") == "usereastmoney"
+
+
+def test_reports_and_formatters(tmp_path, capsys):
+    mcp = tmp_path / "mcp_servers"
+    mcp.mkdir()
+    make_server(mcp, "user-yfinance", docker=True, tools=True)
+    make_server(mcp, "user_openalex")
+    make_server(mcp, "broken", source="x = (")
+    report = mod.check_all_servers(mcp)
+    assert report["total_servers"] == 3
+    assert report["servers_with_server_py"] == 3
+    assert report["servers_with_dockerfile"] == 1
+    assert report["summary"]["compile_error_count"] == 1
+    priority = mod.get_priority_servers_report(mcp)
+    assert priority["priority_count"] == 2
+    single = mod.get_single_server_report(mcp, "user-yfinance")
+    assert single["status"] == "ready"
+    mod.print_summary_line(report)
+    mod.print_json_report(report)
+    mod.print_human_report(report)
+    mod.print_single_server_report(single)
+    output = capsys.readouterr().out
+    assert "MCP Health:" in output and "user-yfinance" in output
+    json.loads(mod.json.dumps(report))
+
+
+def test_main_modes(tmp_path, monkeypatch, capsys):
+    project = tmp_path
+    mcp = project / "mcp_servers"
+    mcp.mkdir()
+    make_server(mcp, "user-yfinance", docker=True)
+
+    for args in (
+        ["health_check_mcp.py", "--summary", "--project-root", str(project)],
+        ["health_check_mcp.py", "--json", "--project-root", str(project)],
+        ["health_check_mcp.py", "--server", "user-yfinance", "--project-root", str(project)],
+        ["health_check_mcp.py", "--server", "missing", "--project-root", str(project)],
+        ["health_check_mcp.py", "--priority-only", "--summary", "--project-root", str(project)],
+    ):
+        monkeypatch.setattr(sys, "argv", args)
+        with pytest.raises(SystemExit) as exc:
+            mod.main()
+        assert exc.value.code == 0
+    assert "MCP Health" in capsys.readouterr().out

--- a/tests/test_on_enter_coverage.py
+++ b/tests/test_on_enter_coverage.py
@@ -1,0 +1,117 @@
+"""Behavior coverage for the interactive project entry helper."""
+
+from __future__ import annotations
+
+import importlib.util
+import builtins
+from datetime import date
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).parents[1] / "scripts" / "on_enter.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("finai_on_enter", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_calendar_covers_month_boundaries_and_release_windows(monkeypatch):
+    module = load_module()
+    seen = set()
+    for current in (date(2026, 1, 2), date(2026, 1, 12), date(2026, 1, 20), date(2026, 12, 31)):
+        monkeypatch.setattr(module, "date", type("FixedDate", (date,), {"today": classmethod(lambda cls, d=current: d)}))
+        events = module._get_macro_today()
+        assert events
+        seen.update(event["name"] for event in events)
+    assert seen >= {"US NFP", "US CPI", "CN PMI"}
+
+
+def test_state_helpers_handle_missing_malformed_and_valid_state(tmp_path, monkeypatch):
+    module = load_module()
+    monkeypatch.setattr(module, "PROJECT_ROOT", tmp_path)
+    assert module._check_daemon()["daemon_running"] is False
+    assert module._get_pending_approvals() == 0
+
+    data = tmp_path / "data"
+    data.mkdir()
+    (data / "event_monitor.pid").write_text("not-a-pid")
+    (data / "event_trigger_state.json").write_text('{"pending": {"a": {}}, "run": {"timestamp": "now"}}')
+    status = module._check_daemon()
+    assert status["last_run"] == "now"
+    assert module._get_pending_approvals() == 1
+
+    (data / "event_trigger_state.json").write_text("{")
+    assert module._check_daemon()["last_run"] is None
+    assert module._get_pending_approvals() == 0
+    monkeypatch.setattr(module, "_get_running_pipelines", lambda: ["a", "b"])
+    assert module._get_running_pipelines() == ["a", "b"]
+
+
+def test_render_helpers_and_actions(monkeypatch, tmp_path, capsys):
+    module = load_module()
+    monkeypatch.setattr(module, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(module, "_get_running_pipelines", lambda: 2)
+    monkeypatch.setattr(module, "_get_pending_approvals", lambda: 1)
+    module.print_banner()
+    module.print_macro_calendar([
+        {"name": "A", "date": "today", "days": 0, "status": "TODAY"},
+        {"name": "B", "date": "soon", "days": 2, "status": "upcoming"},
+        {"name": "C", "date": "later", "days": "next month", "status": "upcoming"},
+    ])
+    module.print_status({"daemon_running": True, "pid": 12, "last_run": "now"})
+    module.print_menu()
+    output = capsys.readouterr().out
+    assert "FinResearch" in output and "待审批" in output
+
+    monkeypatch.setattr(module, "_check_daemon", lambda: {})
+    monkeypatch.setattr(builtins, "input", lambda _prompt="": "")
+    calls = []
+    monkeypatch.setattr(module.subprocess, "run", lambda args, **kwargs: calls.append((args, kwargs)))
+    monkeypatch.setattr(module, "_get_pending_approvals", lambda: 0)
+    for choice in ("1", "2", "3", "4", "5", "7", "9", "invalid"):
+        assert module.run_action(choice) is True
+    assert len(calls) >= 6
+    assert module.run_action("0") is False
+
+
+def test_action_setup_and_approval_paths(monkeypatch, tmp_path):
+    module = load_module()
+    monkeypatch.setattr(module, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(module, "_check_daemon", lambda: {})
+    monkeypatch.setattr(module, "_get_pending_approvals", lambda: 1)
+    monkeypatch.setattr(builtins, "input", lambda _prompt="": "run-1")
+    calls = []
+    monkeypatch.setattr(module.subprocess, "run", lambda args, **kwargs: calls.append(args))
+    (tmp_path / "config" / "daemon").mkdir(parents=True)
+    (tmp_path / "config" / "daemon" / "setup-daemon.sh").write_text("#!/bin/sh\n")
+    for choice in ("6", "8"):
+        assert module.run_action(choice) is True
+    assert any("--approve" in args for args in calls)
+
+
+def test_research_prompt_and_main_exit(monkeypatch, tmp_path):
+    module = load_module()
+    monkeypatch.setattr(module, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(module, "_check_daemon", lambda: {"daemon_running": False, "pid": None, "last_run": None})
+    monkeypatch.setattr(module, "_get_running_pipelines", lambda: 0)
+    monkeypatch.setattr(module, "_get_pending_approvals", lambda: 0)
+    monkeypatch.setattr(module.subprocess, "run", lambda *args, **kwargs: None)
+    inputs = iter(["carbon pricing", ""])
+    monkeypatch.setattr(builtins, "input", lambda _prompt="": next(inputs))
+    assert module.run_action("R") is True
+
+    def end_input(_prompt=""):
+        raise EOFError
+
+    monkeypatch.setattr(builtins, "input", end_input)
+    module.main()
+
+
+def test_running_pipeline_fallback(monkeypatch):
+    module = load_module()
+    monkeypatch.setitem(__import__("sys").modules, "scripts.event_monitor", None)
+    assert module._get_running_pipelines() == 0

--- a/tests/test_paper_reader_exec.py
+++ b/tests/test_paper_reader_exec.py
@@ -1,9 +1,18 @@
-"""tests/test_paper_reader_exec.py — Deeper paper_reader tests."""
+"""Behavior tests for the local-only parts of ``paper_reader``.
+
+Network and LLM calls are replaced with deterministic fakes.  These tests are
+deliberately assertion-heavy: a swallowed exception here would make the CLI
+look healthy while silently losing papers or notes.
+"""
 
 from __future__ import annotations
 
+import json
 import sys
+import types
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 
@@ -11,139 +20,164 @@ ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-try:
-    from scripts import paper_reader as mod
-except Exception as _exc:
-    pytest.skip(f"paper_reader not importable: {_exc}", allow_module_level=True)
+from scripts import paper_reader as mod
 
 
-class TestArxivID:
-    def test_basic(self):
-        fn = getattr(mod, "arxiv_id_from_url", None)
-        if fn is None: pytest.skip("not present")
-        try:
-            r = fn("2301.12345")
-            assert r == "2301.12345"
-        except Exception:
-            pass
+class Response:
+    def __init__(self, body: bytes, status: int = 200):
+        self.body = body
+        self.status = status
 
-    def test_url(self):
-        fn = getattr(mod, "arxiv_id_from_url", None)
-        if fn is None: pytest.skip("not present")
-        try:
-            r = fn("https://arxiv.org/abs/2301.12345")
-            assert r == "2301.12345"
-        except Exception:
-            pass
+    def read(self):
+        return self.body
 
-    def test_pdf(self):
-        fn = getattr(mod, "arxiv_id_from_url", None)
-        if fn is None: pytest.skip("not present")
-        try:
-            r = fn("https://arxiv.org/pdf/2301.12345.pdf")
-            assert r == "2301.12345"
-        except Exception:
-            pass
+    def __enter__(self):
+        return self
 
-    def test_other(self):
-        fn = getattr(mod, "arxiv_id_from_url", None)
-        if fn is None: pytest.skip("not present")
-        try:
-            r = fn("garbage")
-            assert r is not None
-        except Exception:
-            pass
+    def __exit__(self, *_args):
+        return False
 
 
-class TestSanitize:
-    def test_basic(self):
-        fn = getattr(mod, "sanitize_filename", None)
-        if fn is None: pytest.skip("not present")
-        try:
-            r = fn("test_file.pdf")
-            assert isinstance(r, str)
-        except Exception:
-            pass
-
-    def test_special(self):
-        fn = getattr(mod, "sanitize_filename", None)
-        if fn is None: pytest.skip("not present")
-        try:
-            r = fn("test/file?name.pdf")
-            assert "/" not in r
-        except Exception:
-            pass
+@pytest.fixture
+def paper_dirs(tmp_path, monkeypatch):
+    fulltext = tmp_path / "fulltext"
+    meta = tmp_path / "meta"
+    fulltext.mkdir()
+    meta.mkdir()
+    monkeypatch.setattr(mod, "PAPERS_DIR", fulltext)
+    monkeypatch.setattr(mod, "META_DIR", meta)
+    return fulltext, meta
 
 
-class TestPaperReader:
-    def test_default(self):
-        cls = getattr(mod, "PaperReader", None)
-        if cls is None: pytest.skip("not present")
-        try:
-            obj = cls()
-            assert obj is not None
-        except Exception:
-            pass
-
-    def test_custom_storage(self, tmp_path):
-        cls = getattr(mod, "PaperReader", None)
-        if cls is None: pytest.skip("not present")
-        try:
-            obj = cls(storage_dir=str(tmp_path))
-            assert obj is not None
-        except Exception:
-            pass
+def test_arxiv_and_filename_helpers_are_strictly_normalized():
+    assert mod.arxiv_id_from_url("https://arxiv.org/abs/2301.12345v2") == "2301.12345v2"
+    assert mod.arxiv_id_from_url("https://arxiv.org/pdf/2301.12345.pdf") == "2301.12345"
+    assert mod.arxiv_id_from_url("  custom-id  ") == "custom-id"
+    assert mod.sanitize_filename('a/b:c*?.pdf') == "a_b_c__.pdf"
+    assert len(mod.sanitize_filename("x" * 100)) == 80
 
 
-class TestFunctions:
-    def test_download_from_arxiv(self):
-        fn = getattr(mod, "download_from_arxiv", None)
-        if fn is None: pytest.skip("not present")
-        # audit-2026-07-21: try/except/Exception:pass converted to xfail
-        pytest.xfail(
-            reason="no real assertion",
-        )
+def test_loaders_handle_missing_and_truncate_text(paper_dirs):
+    fulltext, meta = paper_dirs
+    assert mod.load_paper_text("missing") == ""
+    assert mod.load_paper_meta("missing") == {}
+    (fulltext / "1.txt").write_text("abcdef", encoding="utf-8")
+    (meta / "1.json").write_text('{"title":"T"}', encoding="utf-8")
+    assert mod.load_paper_text("1", max_chars=3) == "abc"
+    assert mod.load_paper_meta("1") == {"title": "T"}
 
 
-class TestAllDefExists:
-    def test_all_functions_exist(self):
-        for name in [
-            "download_from_arxiv", "get_from_semantic_scholar",
-            "load_paper_text", "load_paper_meta",
-            "summarize_with_ai", "ask_paper_with_ai",
-            "compare_papers_with_ai", "generate_reading_notes",
-            "main",
-        ]:
-            fn = getattr(mod, name, None)
-            assert fn is not None, f"{name} not found"
+def test_download_parses_atom_and_reuses_existing_text(paper_dirs, monkeypatch):
+    fulltext, meta_dir = paper_dirs
+    (fulltext / "2301.12345.txt").write_text("paper body", encoding="utf-8")
+    atom = b'''<feed xmlns="http://www.w3.org/2005/Atom"><entry>
+      <title>  A test paper\n</title><summary> An abstract </summary>
+      <published>2024-02-03T00:00:00Z</published>
+      <author><name>Alice</name></author><author><name>Bob</name></author>
+      <category term="cs.AI" />
+    </entry></feed>'''
+    calls = []
+
+    def fake_urlopen(request, timeout):
+        calls.append((getattr(request, "full_url", request), timeout))
+        return Response(atom)
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    result = mod.download_from_arxiv("https://arxiv.org/abs/2301.12345")
+
+    assert result["arxiv_id"] == "2301.12345"
+    assert result["title"] == "A test paper"
+    assert result["authors"] == ["Alice", "Bob"]
+    assert result["word_count"] == len("paper body")
+    saved = json.loads((meta_dir / "2301.12345.json").read_text(encoding="utf-8"))
+    assert saved["categories"] == ["cs.AI"]
+    assert len(calls) == 2  # metadata plus PDF; existing text avoids extraction
 
 
-class TestCliCommands:
-    def test_cmd_download(self):
-        fn = getattr(mod, "cmd_download", None)
-        if fn is None: pytest.skip("not present")
-        assert callable(fn)
-    def test_cmd_summarize(self):
-        fn = getattr(mod, "cmd_summarize", None)
-        if fn is None: pytest.skip("not present")
-        assert callable(fn)
-    def test_cmd_ask(self):
-        fn = getattr(mod, "cmd_ask", None)
-        if fn is None: pytest.skip("not present")
-        assert callable(fn)
-    def test_cmd_read(self):
-        fn = getattr(mod, "cmd_read", None)
-        if fn is None: pytest.skip("not present")
-        assert callable(fn)
-    def test_cmd_compare(self):
-        fn = getattr(mod, "cmd_compare", None)
-        if fn is None: pytest.skip("not present")
-        assert callable(fn)
-    def test_cmd_notes(self):
-        fn = getattr(mod, "cmd_notes", None)
-        if fn is None: pytest.skip("not present")
-        assert callable(fn)
-    def test_cmd_list(self):
-        fn = getattr(mod, "cmd_list", None)
-        if fn is None: pytest.skip("not present")
-        assert callable(fn)
+def test_download_reports_network_and_xml_errors(paper_dirs, monkeypatch):
+    import urllib.error
+
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        Mock(side_effect=urllib.error.URLError("offline")),
+    )
+    assert "无法连接" in mod.download_from_arxiv("2301.12345")["error"]
+
+    monkeypatch.setattr("urllib.request.urlopen", lambda *_args, **_kwargs: Response(b"<broken>"))
+    assert "XML 解析失败" in mod.download_from_arxiv("2301.12345")["error"]
+
+
+def test_semantic_scholar_requires_identifier_and_uses_cache(paper_dirs, monkeypatch):
+    fulltext, _ = paper_dirs
+    assert mod.get_from_semantic_scholar() == {"error": "需要提供 arXiv ID 或论文标题"}
+    cache = fulltext / ".semantic_cache" / "2301.12345.json"
+    cache.parent.mkdir()
+    cache.write_text('{"title":"cached"}', encoding="utf-8")
+    monkeypatch.setattr(mod.time, "sleep", lambda _seconds: pytest.fail("cache should avoid rate limit"))
+    assert mod.get_from_semantic_scholar(arxiv_id="2301.12345") == {"title": "cached"}
+
+
+def test_semantic_scholar_parses_response_and_handles_http_error(paper_dirs, monkeypatch):
+    import urllib.error
+
+    payload = {"title": "T", "authors": [{"name": "A"}], "year": 2024,
+               "abstract": "abs", "venue": "J", "citationCount": 7,
+               "openAccessPdf": {"url": "https://example.test/t.pdf"}}
+    monkeypatch.setattr(mod.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr("urllib.request.urlopen", lambda *_args, **_kwargs: Response(json.dumps(payload).encode()))
+    result = mod.get_from_semantic_scholar(title="A paper")
+    assert result == {"title": "T", "authors": ["A"], "year": 2024, "abstract": "abs",
+                      "venue": "J", "citations": 7, "pdf_url": "https://example.test/t.pdf"}
+
+    error = urllib.error.HTTPError("url", 404, "missing", {}, None)
+    monkeypatch.setattr("urllib.request.urlopen", Mock(side_effect=error))
+    assert mod.get_from_semantic_scholar(arxiv_id="other") == {"error": "Semantic Scholar 上未找到论文"}
+
+
+def test_notes_and_paper_reader_delegate(paper_dirs, monkeypatch):
+    _, meta_dir = paper_dirs
+    (meta_dir / "1.json").write_text(json.dumps({"title": "Title", "authors": ["A", "B"],
+                                                  "published": "2024-01-01"}), encoding="utf-8")
+    monkeypatch.setattr(mod, "summarize_with_ai", lambda aid, detail="medium": f"summary-{aid}-{detail}")
+    path, content = mod.generate_reading_notes("1")
+    assert Path(path).exists()
+    assert "summary-1-medium" in content and "2024" in content
+
+    reader = mod.PaperReader(storage_dir="custom")
+    assert reader.storage_dir == "custom"
+    assert reader.read("1") == ""
+    assert reader.summarize("1") == "summary-1-medium"
+    monkeypatch.setattr(mod, "ask_paper_with_ai", lambda aid, question: f"answer-{aid}-{question}")
+    assert reader.ask("1", "q") == "answer-1-q"
+    monkeypatch.setattr(mod, "compare_papers_with_ai", lambda aids, question: f"compare-{aids}-{question}")
+    assert reader.compare("1", "2", "q") == "compare-['1', '2']-q"
+
+
+def test_ai_wrappers_use_gateway_and_short_summary(monkeypatch, paper_dirs):
+    _, meta_dir = paper_dirs
+    (meta_dir / "1.json").write_text(json.dumps({"title": "Title", "authors": ["A"],
+                                                  "abstract": "Abstract", "word_count": 10}), encoding="utf-8")
+    fake_gateway = Mock()
+    fake_gateway.generate.return_value = SimpleNamespace(response="generated")
+    monkeypatch.setitem(sys.modules, "scripts.ai_router", types.SimpleNamespace(Task=SimpleNamespace(CODE_ANALYSIS="code")))
+    monkeypatch.setitem(sys.modules, "scripts.core.llm_gateway", types.SimpleNamespace(LLMGateway=lambda **_: fake_gateway))
+    assert mod.summarize_with_ai("1", detail="short") == "generated"
+    assert mod.ask_paper_with_ai("1", "What?") == "generated"
+    assert "generated" == mod.compare_papers_with_ai(["1", "1"], "compare")
+    assert fake_gateway.generate.call_count == 3
+
+
+def test_cli_read_list_and_download_commands(paper_dirs, monkeypatch, capsys):
+    fulltext, meta_dir = paper_dirs
+    (fulltext / "1.txt").write_text("hello world", encoding="utf-8")
+    (meta_dir / "1.json").write_text(json.dumps({"arxiv_id": "1", "title": "T",
+                                                  "authors": ["A"], "word_count": 11,
+                                                  "downloaded_at": "2024-01-01"}), encoding="utf-8")
+    mod.cmd_read(SimpleNamespace(arxiv_ids=["1"], max_chars=5))
+    mod.cmd_list(SimpleNamespace())
+    output = capsys.readouterr().out
+    assert "显示字数" in output and "已下载论文" in output and "hello" in output
+
+    monkeypatch.setattr(mod, "download_from_arxiv", lambda aid: {"arxiv_id": aid, "title": "T", "word_count": 1})
+    result = mod.cmd_download(SimpleNamespace(arxiv_ids=["1", "2"]))
+    assert [r["arxiv_id"] for r in result] == ["1", "2"]

--- a/tests/test_pipeline_builder_unit.py
+++ b/tests/test_pipeline_builder_unit.py
@@ -1,45 +1,121 @@
-"""Unit tests for scripts/pipeline_builder.py."""
+"""Pure-Python tests for pipeline_builder's state and serialization layer."""
+
 from __future__ import annotations
 
-import sys
 from pathlib import Path
+from types import SimpleNamespace
 
-import pytest
+import yaml
 
-SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
-
-
-@pytest.fixture
-def pb():
-    _p = str(SCRIPTS_DIR)
-    if _p not in sys.path:
-        sys.path.insert(0, _p)
-    from scripts import pipeline_builder as p
-    yield p
-    if _p in sys.path:
-        sys.path.remove(_p)
+from scripts import pipeline_builder as pb
 
 
-class TestConstants:
-    def test_all_agent_names(self, pb):
-        assert isinstance(pb.ALL_AGENT_NAMES, (list, set))
-        assert len(pb.ALL_AGENT_NAMES) > 0
+class State(dict):
+    def __getattr__(self, name):
+        try:
+            return self[name]
+        except KeyError as exc:
+            raise AttributeError(name) from exc
 
-    def test_analyst_agents(self, pb):
-        assert isinstance(pb.ANALYST_AGENTS, (list, dict, set))
-        assert len(pb.ANALYST_AGENTS) > 0
+    def __setattr__(self, name, value):
+        self[name] = value
 
-    def test_analyst_stages(self, pb):
-        assert isinstance(pb.ANALYST_STAGES, (list, dict, set))
 
-    def test_paper_agents(self, pb):
-        assert isinstance(pb.PAPER_AGENTS, (list, dict, set))
+class FakeStreamlit:
+    def __init__(self):
+        self.session_state = State()
+        self.errors = []
 
-    def test_paper_stages(self, pb):
-        assert isinstance(pb.PAPER_STAGES, (list, dict, set))
+    def error(self, message):
+        self.errors.append(message)
 
-    def test_category_colors(self, pb):
-        assert isinstance(pb.CATEGORY_COLORS, dict)
 
-    def test_config_yaml_exists(self, pb):
-        assert hasattr(pb, "CONFIG_YAML")
+def install_state(monkeypatch):
+    fake = FakeStreamlit()
+    monkeypatch.setattr(pb, "st", fake)
+    pb._init_state()
+    return fake
+
+
+def test_categories_and_stage_colors_are_stable():
+    assert pb._agent_category("outline") == "paper"
+    assert pb._agent_category("valuation") == "analyst"
+    assert pb._agent_category("unknown") == "utility"
+    assert pb._stage_color(0) == "#9B59B6"
+    assert pb._stage_color(len(pb.PAPER_STAGES) + len(pb.ANALYST_STAGES)) == "#34495E"
+
+
+def test_init_build_and_validate_pipeline(monkeypatch):
+    fake = install_state(monkeypatch)
+    assert fake.session_state.pb_pipeline_name == "my_pipeline"
+    fake.session_state.pb_pipeline_name = "  demo  "
+    fake.session_state.pb_pipeline_desc = "  description  "
+    fake.session_state.pb_steps = [{
+        "agent": "outline", "stage": "OUTLINE", "hitl_gate": True,
+        "max_iterations": 4, "depends_on": ["previous"],
+    }]
+    fake.session_state.pb_agent_data = {"outline": {"role": "writer"}}
+    built = pb._build_pipeline_yaml()
+    assert built["name"] == "demo"
+    assert built["description"] == "description"
+    assert built["steps"][0]["max_iterations"] == 4
+    assert built["steps"][0]["depends_on"] == ["previous"]
+    assert pb._validate_pipeline() == []
+
+    fake.session_state.pb_steps.append(dict(fake.session_state.pb_steps[0]))
+    assert any("Duplicate" in error for error in pb._validate_pipeline())
+    fake.session_state.pb_steps = [{"agent": "missing", "stage": "OUTLINE"}]
+    assert any("Unknown agent" in error for error in pb._validate_pipeline())
+    fake.session_state.pb_steps = []
+    fake.session_state.pb_pipeline_name = ""
+    errors = pb._validate_pipeline()
+    assert "Pipeline name is required." in errors
+    assert "Add at least one step to the pipeline." in errors
+
+
+def test_reload_save_generate_and_load_pipeline(tmp_path, monkeypatch):
+    fake = install_state(monkeypatch)
+    config = tmp_path / "agents.yaml"
+    config.write_text(yaml.safe_dump({
+        "agents": {"outline": {"role": "writer"}},
+        "analysts": {"valuation": {"role": "analyst"}},
+        "pipelines": {"old": {"description": "old", "steps": [
+            {"agent": "outline", "stage": "OUTLINE", "hitl_gate": True, "depends_on": ["x"]}
+        ]}},
+    }), encoding="utf-8")
+    monkeypatch.setattr(pb, "CONFIG_YAML", config)
+    drafts = tmp_path / "drafts"
+    drafts.mkdir()
+    monkeypatch.setattr(pb, "DRAFT_DIR", drafts)
+    pb._reload_yaml()
+    assert fake.session_state.pb_loaded is True
+    assert fake.session_state.pb_agent_data["outline"]["category"] == "paper"
+    assert fake.session_state.pb_agent_data["valuation"]["category"] == "analyst"
+
+    fake.session_state.pb_pipeline_name = "demo/name"
+    fake.session_state.pb_pipeline_desc = "desc"
+    fake.session_state.pb_steps = [{"id": "1", "agent": "outline", "stage": "OUTLINE"}]
+    draft = pb._save_draft()
+    assert draft.exists() and "/" not in draft.name
+    saved = yaml.safe_load(draft.read_text(encoding="utf-8"))
+    assert saved["pipeline"]["description"] == "desc"
+
+    output = pb._generate_yaml_output()
+    parsed = yaml.safe_load(output)
+    assert parsed["pipelines"]["demo/name"]["name"] == "demo/name"
+
+    fake.session_state.pb_pipelines = {
+        "old": {"description": "old", "steps": [{"agent": "outline", "stage": "OUTLINE"}]}
+    }
+    pb._load_pipeline("old")
+    assert fake.session_state.pb_pipeline_name == "old"
+    assert fake.session_state.pb_steps[0]["agent"] == "outline"
+    assert fake.session_state.pb_steps[0]["id"]
+    assert fake.session_state.pb_selected_step is None
+
+
+def test_reload_reports_missing_config(monkeypatch, tmp_path):
+    fake = install_state(monkeypatch)
+    monkeypatch.setattr(pb, "CONFIG_YAML", tmp_path / "missing.yaml")
+    pb._reload_yaml()
+    assert fake.errors and "not found" in fake.errors[0]


### PR DESCRIPTION
## Summary
- raise the aggregate CI branch coverage gate from 55% to 60%
- raise the critical research-path gate from 75% to 80% (local measured 87.4%)
- add deterministic behavior coverage for paper readers, pipeline builder, health checks, Excel generators, and paper agents
- fix verified runtime defects in paper reader, pipeline builder, Excel schema handling, paper agents, tool log rotation, and direct audit-guard execution
- update coverage documentation and badge to the verified 60.0% result

## Verification
- full CI-equivalent suite: 12,881 passed, 157 skipped, 82 xfailed, 3 xpassed
- full branch coverage: 60.0%
- critical research-path branch coverage: 87.4%
- targeted regression suite: 134 passed
- audit guard: 25/25 passed
