### PR TITLE
fix: deepen repository and GitHub maintenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,16 @@ updates:
     # lock entry alone creates an uninstallable Dependabot PR.
     ignore:
       - dependency-name: "pydantic-core"
+      # MCP 2.x currently breaks server compatibility tests (list_tools API
+      # changes). Keep the validated 1.x line until an explicit migration.
+      - dependency-name: "mcp"
+        update-types:
+          - "version-update:semver-major"
+      # OpenAI 2.x is a runtime-major upgrade; the project still validates the
+      # OpenAI 1.x API and does not yet have an integration migration suite.
+      - dependency-name: "openai"
+        update-types:
+          - "version-update:semver-major"
     # Auto-rebase to keep PRs in sync with main.
     rebase-strategy: "auto"
     labels:

--- a/Makefile
+++ b/Makefile
@@ -71,10 +71,10 @@ format:
 # ─── Documentation ─────────────────────────────────────────────────────────────
 
 docs:
-	cd docs && mkdocs build
+	mkdocs build -f mkdocs.yml
 
 docs-serve:
-	cd docs && mkdocs serve
+	mkdocs serve -f mkdocs.yml
 
 # ─── Demo & Pipeline ───────────────────────────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > **研究主题一句话 → 收到可投稿的 LaTeX 草稿。**
 > **Describe your research topic → receive a submission-ready LaTeX draft.**
 
-![FinAI Research Workflow Banner](docs/assets/banner.svg)
+![FinAI Research Workflow](docs/assets/social-preview.png)
 
 [![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12-3776AB?logo=python&logoColor=white)](https://github.com/csmar432/finai-research)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
@@ -76,7 +76,7 @@ for the full inventory and regeneration commands.
 | | |
 |---|---|
 | **43 个 MCP 数据源** | A 股财务 / 美股 / 宏观（FRED/IMF/世界银行） / 学术论文（OpenAlex/ArXiv），28 个无需 API Key |
-| **47 种计量方法** | 标准 DID / 交错 DID（CS/SunAb/Borusyak） / IV / RDD / 合成控制 / 面板 GMM，JF/JFE 级别稳健性检验 |
+| **58 个计量模块** | 覆盖标准 DID / 交错 DID（CS/SunAb/Borusyak） / IV / RDD / 合成控制 / 面板 GMM，JF/JFE 级别稳健性检验 |
 | **30 种期刊模板** | JF / JFE / RFS / 经济研究 / 金融研究 / 管理世界，中英日德四国语言 |
 
 > ⚠️ AI 生成的因果识别策略、统计结果和引用必须由研究者独立核实后方可投稿。
@@ -84,7 +84,7 @@ for the full inventory and regeneration commands.
 
 ---
 
-**完整文档**: [使用指南.md](使用指南.md) · [CLAUDE.md](CLAUDE.md) · [交互式配置向导](python scripts/setup_wizard.py --guided)
+**完整文档**: [使用指南.md](使用指南.md) · [CLAUDE.md](CLAUDE.md) · 运行 `python scripts/setup_wizard.py --guided`
 
 ---
 
@@ -92,10 +92,10 @@ for the full inventory and regeneration commands.
 ## Why FinAI Research Workflow?
 
 - **Built for economists, not generic AI demos** — every default is calibrated for the *Journal of Finance* / *经济研究* standard (DID with heterogeneous treatment effects, cluster-robust SEs at the firm level, 19 robustness checks, parallel-trend plots).
-- **43 MCP server directories** — covers A-share financials, US equities, global macro (FRED/World Bank/IMF/OECD/BEA), and 400M+ academic papers (OpenAlex). **41 directories have full Python implementations; 2 are mock-only (user-csmar, user-wind require institutional accounts); 3 are opt-in legal-risk (CNKI, Wanfang, Chinese Literature)**. Free alternatives exist via `user-financial` (akshare) and `user-yfinance`.
-- **47 econometric method modules, not just OLS** — standard DID, event study, Bacon decomposition, staggered DID (Callaway-Sant'Anna/Sun-Abraham/Borusyak/Goodman-Bacon, requires `pip install diff-in-diff2`), synthetic control, instrumental variables (requires `linearmodels`), panel GMM, RDD, event studies, mediation, and more. See CLAUDE.md for the full list with dependency notes.
+- **43 MCP server directories** — covers A-share financials, US equities, global macro (FRED/World Bank/IMF/OECD/BEA), and 400M+ academic papers (OpenAlex). The registry contains **28 no-key, 12 API-key, 0 stub, and 3 opt-in legal-risk directories**; classification is maintained by `scripts/count_assets.py`.
+- **58 econometric method modules, not just OLS** — standard DID, event study, Bacon decomposition, staggered DID (Callaway-Sant'Anna/Sun-Abraham/Borusyak/Goodman-Bacon, requires `pip install diff-in-diff2`), synthetic control, instrumental variables (requires `linearmodels`), panel GMM, RDD, event studies, mediation, and more. See CLAUDE.md for the full list with dependency notes.
 - **30 journal templates, English/Chinese/Japanese/German** — JF, JFE, RFS, JAE, Econometrica, 经济研究, 金融研究, 管理世界, 会计研究, 中国工业经济.
-- **17 specialised AI skills** (Claude Code / Cursor / GitHub Copilot) — idea discovery, literature review, novelty check, experiment design, data acquisition, paper drafting, figure generation, LaTeX compilation, review loops.
+- **18 specialised AI skills** (Claude Code / Cursor / GitHub Copilot) — idea discovery, literature review, novelty check, experiment design, data acquisition, paper drafting, figure generation, LaTeX compilation, review loops.
 - **Human-in-the-loop, never autonomous fabrication** — every stage requires explicit checkpoint approval; data sources are verified before use; no synthetic data without user consent.
 
 ## Why Not Just Use ChatGPT?
@@ -112,7 +112,7 @@ FinAI is purpose-built for economic & financial research. Here is what it does t
 | **Multi-stage pipeline with checkpoints** | One-off answers | ✅ 8-stage pipeline with human approval |
 
 > [!TIP]
-> Start now with zero setup: **[Open in GitHub Codespaces](https://codespaces.new/csmar432/finai-research)** (free, 120 hours/month). No install required.
+> Start now with zero setup: **[Open in GitHub Codespaces](https://codespaces.new/csmar432/finai-research)**. No local install required.
 
 > **For Chinese users:** The most comprehensive guide is **[使用指南.md](使用指南.md)** — a complete 13-chapter manual covering installation, workflows, data sources, econometric methods, paper writing, and FAQ.
 
@@ -254,7 +254,7 @@ Describe your research in plain Chinese — the agent handles the rest:
 | Stage | Output |
 |-------|--------|
 | Research Design | DID/IV/RDD identification strategy + data sourcing plan |
-| Empirical Analysis | 47 econometric methods, automated robustness tests (19 types) |
+| Empirical Analysis | 58 econometric modules, automated robustness tests (19 types) |
 | Paper Draft | LaTeX manuscript in journal format (JF/JFE/RFS/经济研究/金融研究/管理世界) |
 | Review Loop | AI-assisted adversarial review with researcher verification required |
 
@@ -263,35 +263,20 @@ Describe your research in plain Chinese — the agent handles the rest:
 **Architecture overview:**
 
 ![Architecture Diagram](.github/demo/architecture-diagram.svg)
-*Multi-agent pipeline: User Input → AI Agent → 5-Stage Research Pipeline (outline → literature → plotting → writing → refinement, with optional HITL gates at each stage) → 43 MCP Servers → 47 Econometric Methods → 20 Chart Types → LaTeX Paper*
+*Multi-agent pipeline: User Input → AI Agent → 5-Stage Research Pipeline (outline → literature → plotting → writing → refinement, with optional HITL gates at each stage) → 43 MCP Servers → 58 Econometric Modules → 20 Chart Types → LaTeX Paper*
 
 > **Note:** Demo assets are in `.github/demo/` and `docs/assets/`. The project is actively maintained.
 
 ---
 
-## Key Features
+## Contributor Setup
 
-| Feature | Description |
-|---------|-------------|
-| **Multi-Agent Pipeline** | Orchestrates 5 pipeline agents (outline → literature → plotting → writing → refinement) with optional HITL gates |
-| **43 MCP Data Servers** | 43 registered MCP server directories; **41 are fully implemented in Python (stdlib HTTP + databases)**; 2 are mock-only (user-csmar, user-wind require institutional accounts); 3 are opt-in legal-risk (user-cnki, user-wanfang, user-chinese-literature). Of the 41 real servers, ~28 work without API keys (yfinance, akshare, World Bank, IMF, OECD, FRED, ArXiv, NBER, OpenAlex, SEC EDGAR, eastmoney, etc.); 11 require API keys (Tushare Pro, CEIC, EODHD, etc.). Run `python scripts/count_assets.py` for the latest breakdown. |
-| **47 Econometric Methods** | DID (5 variants), RDD, synthetic control, panel GMM, spatial regression, IV/2SLS, causal ML, GARCH, survival analysis, panel cointegration — JF/JFE/RFS standard. Modern staggered DID (Callaway-Sant'Anna, Borusyak, Sun-Abraham) requires `pip install diff-in-diff2` |
-| **Provenance Tracking** | Full data lineage from raw API to final chart/table |
-| **HITL Gates** | Human-in-the-loop approval at critical pipeline stages |
-| **Analyst Agents** | Financial analysis agents for fundamental, valuation, risk, earnings, competitive, and macro research |
-| **Self-Evolution** | Continuous improvement based on task outcomes |
-| **45 Journal Templates** | JF, JFE, RFS, JAE, Econometrica + 经济研究/金融研究/管理世界/会计研究/中国工业经济 etc. |
-
----
-
-## Quick Start
-
-### 5-Minute Setup
+### Source checkout
 
 ```bash
 # 1. Clone the repository
 git clone https://github.com/csmar432/finai-research.git
-cd finai-research-workflow
+cd finai-research
 
 # 2. Install the package with all common optional integrations
 python3 -m venv .venv && source .venv/bin/activate
@@ -312,35 +297,17 @@ python scripts/research_framework/pipeline.py --topic "碳排放权交易对企�
 # Or use an AI Agent (recommended) for the full interactive workflow
 ```
 
-### Via Cursor (Recommended)
-
-Simply describe your research goal in natural language:
-
-```
-帮我分析碳排放权交易对企业绿色创新的影响，设计一篇实证论文，发表在经济研究
-```
-
-AI Agent will automatically call all necessary modules.
-
----
-
-## Architecture
-
-The system uses a **layered agent architecture** with an AI Agent (Claude Code / Cursor / Codex) as the orchestrator:
-
-![Architecture Diagram](.github/demo/architecture-diagram.svg)
-
 **Key numbers** (auto-generated by `scripts/count_assets.py`):
 
 | Metric | Count |
 |--------|------:|
 | MCP server directories | 43 (28 free, 12 API-key, 0 stub, 3 opt-in) |
-| Econometric method modules | 47 |
+| Econometric method modules | 58 |
 | Journal templates | 30 |
-| AI Skills | 17 |
-| Research directions | 12 |
-| Test files / test functions | 98 / 296 |
-| research_framework modules with tests | 21/47 |
+| AI Skills | 18 |
+| Research directions | 45 registered |
+| Test files / test functions | 665 / 12,700 |
+| research_framework modules with tests | 56/58 |
 
 > Run `python scripts/count_assets.py` to regenerate these numbers. They are checked into README as a snapshot of the latest count; CI is the source of truth.
 
@@ -385,7 +352,7 @@ See [MCP Tool Marketplace Tutorial](docs/tutorials/04-mcp-marketplace.md) for th
 
 ---
 
-## Available Skills (17)
+## Available Skills (18)
 
 Each skill is documented in `.claude/skills/` (Claude Code) and `.github/skills/` (GitHub Copilot). In Cursor, use the `Skill:` command directly.
 
@@ -428,8 +395,8 @@ Each skill is documented in `.claude/skills/` (Claude Code) and `.github/skills/
 | Document | Description |
 |----------|-------------|
 | [SETUP_GUIDE.md](SETUP_GUIDE.md) | Environment setup, API keys, Docker |
-| [USAGE_GUIDE.md](USAGE_GUIDE.md) | Complete usage guide (Chinese) |
-| [QUICKSTART.md](QUICKSTART.md) | 5-minute quick start |
+| [使用指南.md](使用指南.md) | Complete usage guide (Chinese) |
+| [docs/tutorials/01-quickstart.md](docs/tutorials/01-quickstart.md) | 5-minute quick start |
 | [CLAUDE.md](CLAUDE.md) | Agent configuration and capabilities |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | Contribution guidelines |
 | [docs/tutorials/](docs/tutorials/) | Step-by-step tutorials |
@@ -594,7 +561,7 @@ flowchart TD
 
 > **Pipeline stages note:** The core pipeline has **5 stages** (outline → literature → plotting → writing → refinement) with optional HITL gates. Idea generation, novelty verification, and data acquisition run as parallel/prior stages. The research framework CLI (`scripts/research_framework/pipeline.py`) provides a focused DID/IV/RDD analysis mode.
 
-### MCP Data Source Selection (43 Directories: 41 Real + 2 Mock + 3 Opt-in Legal)
+### MCP Data Source Selection (43 directories: 28 no-key + 12 API-key + 3 opt-in legal)
 
 ```mermaid
 flowchart LR
@@ -657,7 +624,7 @@ This focus brings complementary features for economists:
 
 - **43 MCP data sources** for A-share financials (Tushare/CSMAR/Wind), US equities (yfinance),
   global macro (FRED/World Bank/IMF/OECD/BEA), and 400M+ academic papers (OpenAlex/ArXiv).
-- **47 econometric method modules** including modern staggered DID
+- **58 econometric method modules** including modern staggered DID
   (Callaway-Sant'Anna, Sun-Abraham, Borusyak), synthetic control/DiD, IV/2SLS,
   panel GMM, RDD, triple-diff, panel quantile, spatial regression, etc.
 - **30 journal templates** (EN+ZH+JP+DE) covering *JF / JFE / RFS / JPE / Econometrica /

--- a/README_EN.md
+++ b/README_EN.md
@@ -6,9 +6,11 @@
 >
 > ⚠️ **Legal Risk Servers**: 3 MCP servers (`user-cnki`, `user-wanfang`, `user-chinese-literature`) scrape websites that prohibit automated access. **They are disabled by default for all users.** See [LEGAL_CONSENT.md](LEGAL_CONSENT.md) to understand the risk and opt-in with `CLI_ACCEPT_RISK`.
 
+![FinAI Research Workflow](docs/assets/social-preview.png)
+
 [![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12-3776AB?logo=python&logoColor=white)](https://github.com/csmar432/finai-research)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Install](https://img.shields.io/badge/install-git%20clone%20%26%20pip%20install%20-e%20.-blue)](https://github.com/csmar432/finai-research#installation)
+[![Install](https://img.shields.io/badge/install-git%20clone%20%26%20pip%20install%20-e%20.-blue)](README.md)
 [![GitHub release](https://img.shields.io/github/v/release/csmar432/finai-research?color=blue)](https://github.com/csmar432/finai-research/releases)
 [![GitHub stars](https://img.shields.io/github/stars/csmar432/finai-research)](https://github.com/csmar432/finai-research/stargazers)
 [![arXiv](https://img.shields.io/badge/arXiv-cs.AI-b31b1b.svg)](https://arxiv.org/)
@@ -19,7 +21,7 @@
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21262689.svg)](https://doi.org/10.5281/zenodo.21262689)
 [![GitHub stars](https://img.shields.io/github/stars/csmar432/finai-research?style=social)](https://github.com/csmar432/finai-research/stargazers)
 
-[🇨🇳 **中文文档**](README.md) · [🇬🇧 **English Documentation**](#)
+[🇨🇳 **中文文档**](README.md) · [🇬🇧 **English Documentation**](README_EN.md)
 
 ---
 
@@ -33,7 +35,7 @@
 |---|---|
 | **One-line publish script** | `python scripts/release.py` |
 | **API reference** | [scripts/](scripts/) modules with type hints and docstrings |
-| **17 AI skills** | [knowledge/skills/](knowledge/skills/) |
+| **18 AI skills** | [knowledge/skills/](knowledge/skills/) |
 | **Troubleshooting FAQ** | [FAQ.md](FAQ.md) |
 | **Chinese comprehensive guide** | [使用指南.md](使用指南.md) (1049 lines, 13 chapters) |
 
@@ -55,9 +57,9 @@
 
 ## ✨ Core Capabilities
 
-### 📊 Data Acquisition (43 MCP server directories: 41 real + 2 mock + 3 opt-in legal)
+### 📊 Data Acquisition (43 MCP server directories: 28 no-key + 12 API-key + 3 opt-in legal)
 
-> **Note**: ~15 servers are fully free (no API key). Others require institutional/paid accounts (Tushare Pro, Wind, CSMAR, CEIC, EODHD). Some have stub implementations (SIPO, ESG, Chinese Customs, CNRD).
+> **Note**: 28 servers are classified as no-key, 12 require API keys, and 3 opt-in legal-risk sources are disabled by default. The classification is maintained by `scripts/count_assets.py`.
 
 | What you need | MCP server |
 |---|---|
@@ -90,7 +92,7 @@
   - Honest DiD (Rambachan-Roth 2023): requires `pip install honestdid` (the official Python port of the original R HonestDiD package)
 
 
-### 📄 Paper Writing (44 journal templates, English/Chinese)
+### 📄 Paper Writing (30 journal templates, English/Chinese)
 
 - **English top**: JF · JFE · RFS · JAE · JFQA · JPE · Econometrica
 - **Chinese top**: 经济研究 · 金融研究 · 管理世界 · 会计研究 · 中国工业经济
@@ -105,7 +107,7 @@
 
 ### 🏗 Engineering Quality
 
-- ✅ 659 test files, 7 CI jobs, 2-OS matrix (Ubuntu + macOS)
+- ✅ 665 test files, 7 CI jobs, 3-OS matrix (Ubuntu + macOS + Windows)
 - ✅ Coverage report, codecov badge
 - ✅ Pre-commit hooks (ruff + mypy + codespell + commitlint)
 - ✅ Dependabot (pip + GitHub Actions)
@@ -121,7 +123,7 @@
 ```bash
 # 1. Install
 git clone https://github.com/csmar432/finai-research.git
-cd finai-research-workflow
+cd finai-research
 pip install -e ".[dev, econometrics]"  # econometrics adds linearmodels + diff-in-diff2
 
 # 2. Configure API keys
@@ -146,7 +148,7 @@ Step 2  Idea ↔ Data verify  → scripts/idea_data_checker.py (HITL checkpoint)
 Step 3  Literature review   → MCP multi-source, citation network, gap analysis
 Step 4  Novelty check       → JF/JFE/RFS/arXiv search
 Step 5  Empirical design    → DID/IV/RD/PSM/18 robustness checks
-Step 6  Data acquisition    → 43 MCP server directories (41 real implementations + 2 mock + 3 opt-in legal), 4-layer fallback
+Step 6  Data acquisition    → 43 MCP server directories (28 no-key + 12 API-key + 3 opt-in legal), 4-layer fallback
 Step 7  Paper writing       → outline → draft → figures → LaTeX
 Step 8  Adversarial review  → multi-round, until publishable
 ```
@@ -160,16 +162,16 @@ Each step is **independently callable** and **has its own output file** as a sta
 | Metric | Value | Note |
 |---|-------|------|
 | MCP data servers | **43** | 43 directories: 28 fully free, 12 API-key, 3 opt-in legal-risk (CNKI/Wanfang/Chinese Literature) |
-| Econometric methods | **47** | 33/47 with tests; ⭐ self-contained, 🔗 requires linearmodels/diff-in-diff2 |
+| Econometric method modules | **58** | 56/58 modules have tests; ⭐ self-contained, 🔗 requires linearmodels/diff-in-diff2 |
 | Journal templates | **30** | English + Chinese top journals (JF/JFE/RFS/经济研究/金融研究/管理世界/...) |
-| AI skills | **17** | `.cursor/skills/` operational source, 5 fully automated, 12 prompt-driven |
-| Research directions | **15** | digital_finance / green_finance / carbon_economics / ... |
-| Test files / functions | **397 / 7,804** | pytest; ~50K LOC tests |
+| AI skills | **18** | `.cursor/skills/` operational source, 5 fully automated, 13 prompt-driven |
+| Research directions | **45 registered** | digital_finance / green_finance / carbon_economics / ... |
+| Test files / functions | **665 / 12,700** | pytest; count maintained by `scripts/count_assets.py` |
 | Python lines | **~206K scripts + ~98K tests** | |
 | CI jobs | **7 batches × ~40 steps** | lint + 3× smoke + mypy + security + coverage + docker |
-| Coverage | **58.2%** | gate `fail-under=55`, target 60% |
+| Coverage | **60.0% aggregate / 87.4% critical** | aggregate gate `fail-under=60`; critical-path gate 80% |
 
-> Coverage is reported to [Codecov](https://codecov.io/gh/csmar432/finai-research); progressive increase toward 60% target.
+> Coverage is reported to [Codecov](https://codecov.io/gh/csmar432/finai-research); the next aggregate milestone is 65% while critical research paths remain above 80%.
 
 ---
 
@@ -194,7 +196,7 @@ We use PR labeler (`.github/labeler.yml`) for automatic labels.
 ## 🔗 Links
 
 - **Source**: https://github.com/csmar432/finai-research
-- **Install**: `pip install -e ".[extras]"` (clone first; includes Tushare and all common optional integrations) — **not yet published to PyPI**
+- **Install**: `pip install "finai-research-workflow[extras]"` from PyPI, or `pip install -e ".[extras]"` for a source checkout
 - **Issues**: https://github.com/csmar432/finai-research/issues
 - **Discussions**: https://github.com/csmar432/finai-research/discussions
 - **Security**: See [SECURITY.md](SECURITY.md)
@@ -226,38 +228,7 @@ This project is maintained by **[@csmar432](https://github.com/csmar432)**.
 
 ---
 
-## 🛠 8-Step Research Workflow
-
-```
-Step 0  System self-check  → python scripts/health_check.py
-Step 1  Idea generation    → 8-12 ranked ideas for your topic
-Step 1.5 Idea-data check   → Verify data availability BEFORE commitment
-Step 2  Literature review  → Semantic Scholar + ArXiv + OpenAlex + NBER
-Step 3  Novelty check      → JF/JFE/RFS/arXiv dedup → novelty score
-Step 4  Experiment design  → DID/IV/RDD identification strategy
-Step 5  Data acquisition   → 43 MCP server directories (41 real + 2 mock + 3 opt-in legal; free fallback chain)
-Step 6  Paper writing      → Outline → sections → figures → LaTeX
-Step 7  Adversarial review → Multi-round LLM + human review
-```
-
-Each step is independently executable and produces a Markdown artifact
-you can review before proceeding.
-
 ---
-
-## 🧪 Quality Gates (defense against bad research)
-
-This project maintains **3 layers of defense** against LLM-generated
-audit reports that contain hallucinated claims:
-
-| Layer | Mechanism | Catches |
-|-------|-----------|---------|
-| 1 | `scripts/audit_guard.py` (8 deterministic checks) | Fake badges, stale metrics, missing tests |
-| 2 | pre-commit hook (5 cheap checks <3s) | Regression on critical state |
-| 3 | Manual verification protocol | Anything that survives layers 1–2 |
-
-See [docs/audit-workflow.md](docs/audit-workflow.md) for full details
-on why this exists and how to use it.
 
 ---
 
@@ -278,8 +249,8 @@ Run with: `pytest tests/test_numerical_correctness.py -v`
 ## ✨ Why FinAI Research Workflow?
 
 - **Built for economists, not generic AI demos** — every default is calibrated for the *Journal of Finance* / *经济研究* standard (DID with heterogeneous treatment effects, cluster-robust SEs at firm level, 19 robustness checks, parallel-trend plots).
-- **43 MCP server directories** — covers A-share financials, US equities, global macro (FRED/World Bank/IMF/OECD/BEA), and 400M+ academic papers (OpenAlex). 41 directories have full Python implementations; 2 are mock-only (user-csmar, user-wind require institutional accounts); 3 are opt-in legal-risk (CNKI, Wanfang, Chinese Literature). Free alternatives exist via `user-financial` (akshare) and `user-yfinance`.
-- **47 econometric method modules, not just OLS** — standard DID, event study, Bacon decomposition, staggered DID (Callaway-Sant'Anna/Sun-Abraham/Borusyak/Goodman-Bacon), synthetic control, instrumental variables, panel GMM, RDD, mediation, and more.
+- **43 MCP server directories** — covers A-share financials, US equities, global macro (FRED/World Bank/IMF/OECD/BEA), and 400M+ academic papers (OpenAlex). The registry contains **28 no-key, 12 API-key, 0 stub, and 3 opt-in legal-risk directories**; classification is maintained by `scripts/count_assets.py`.
+- **58 econometric method modules, not just OLS** — standard DID, event study, Bacon decomposition, staggered DID (Callaway-Sant'Anna/Sun-Abraham/Borusyak/Goodman-Bacon), synthetic control, instrumental variables, panel GMM, RDD, mediation, and more.
 - **30 journal templates** (EN/ZH/JP/DE) — JF, JFE, RFS, Econometrica, 经济研究, 金融研究, 管理世界, JPE, RES, AEJ Applied, ZWiSt — all with bilingual (English/Chinese) section headings.
 - **Reproducibility first** — every step has a script, every script has a `--seed` flag, every output has data provenance (source, timestamp, hash).
 
@@ -292,7 +263,7 @@ audit reports containing hallucinated claims:
 
 | Layer | Mechanism | Catches |
 |-------|-----------|---------|
-| 1 | `scripts/audit_guard.py` (17 deterministic checks) | Fake badges, stale metrics, missing tests, version drift |
+| 1 | `scripts/audit_guard.py` (25 deterministic checks) | Fake badges, stale metrics, missing tests, version drift |
 | 2 | pre-commit hook (5 cheap checks <3s) | Regression on critical state |
 | 3 | Manual verification protocol | Anything that survives layers 1–2 |
 

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -52,7 +52,7 @@ README 主推前者作为用户入口；后者供框架内调用。
 | `scripts.core.evolution_gate.NoveltyGate` | 新颖性验证（JF/JFE/RFS 查重） |
 | `scripts.core.llm_reviewer.LLMReviewer` | 对抗性 review 循环 |
 
-## 4. 实证设计（47 个方法模块）
+## 4. 实证设计（58 个方法模块）
 
 | 类 | 模块 | 用途 |
 |-----|------|------|
@@ -83,7 +83,7 @@ README 主推前者作为用户入口；后者供框架内调用。
 | `GreenBondFactorModel` | `scripts/research_framework/green_bond_model.py` | Green bond premium / ESG factor decomposition |
 | `IVSurfaceBuilder` | `scripts/research_framework/options_iv_surface.py` | 期权 IV surface + BS solver + Greeks |
 
-> 完整 47 个方法模块列表见 `scripts/research_framework/`，由 `scripts/count_assets.py` 自动统计。
+> 完整模块列表见 `scripts/research_framework/`，当前由 `scripts/count_assets.py` 自动统计为 58 个模块；其中 56 个已有测试覆盖。
 
 ## 5. 数据获取
 
@@ -105,7 +105,7 @@ README 主推前者作为用户入口；后者供框架内调用。
 | `scripts.research_framework.fin_charts.FinancialChartFactory` | 20+ 种专业金融图表（≥300 DPI） |
 | `scripts.journal_template.JournalTemplate` | **30** 种期刊模板（EN/ZH/JP/DE），见 `scripts/count_assets.py` |
 
-## 7. Skills（Cursor / Claude Code / Copilot，17 个）
+## 7. Skills（Cursor / Claude Code / Copilot，18 个）
 
 | Skill | 功能 |
 |-------|------|
@@ -127,7 +127,7 @@ README 主推前者作为用户入口；后者供框架内调用。
 | `fin-ref-paper` | BibTeX 参考文献管理 |
 | `fin-viz-launch` | 自然语言 → 学术图表 |
 
-完整 17 个 skill 文件在 `.cursor/skills/`。
+完整 18 个 skill 文件在 `.cursor/skills/`。
 
 ## 8. MCP 数据源（`{{MCP_COUNT}}` 个目录，自动生成）
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@
 ## 核心能力
 
 - **数据获取**：`{{MCP_COUNT}}` 个 MCP 数据服务器（自动统计，见 `scripts/count_mcp.py`），覆盖 A股/美股/宏观/学术论文
-- **因果推断**：DID / IV / RDD / PSM / 面板 GMM 等 **47** 种计量方法
+- **因果推断**：DID / IV / RDD / PSM / 面板 GMM 等 **58** 个计量模块
 - **论文写作**：支持 JF / JFE / RFS / 经济研究 / 金融研究 等 **30** 种中英文顶刊格式
 - **智能 Review**：多轮对抗性评审循环，自动检查实证严谨性
 
@@ -32,7 +32,6 @@ python scripts/health_check.py --json
 - [事件驱动研究](tutorials/05-event-driven-research.md)
 - [API 参考](api_reference.md)
 - [架构设计](ARCHITECTURE.md)
-- [改进路线](IMPROVEMENT_ROADMAP.md)
 
 ## 可用研究方向
 
@@ -53,5 +52,5 @@ python scripts/health_check.py --json
 ## 链接
 
 - [项目主页](https://github.com/csmar432/finai-research)
-- [使用指南](../使用指南.md)
+- [使用指南](https://github.com/csmar432/finai-research/blob/main/使用指南.md)
 - [安装配置](tutorials/01-quickstart.md)

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -79,5 +79,4 @@ nav:
       - 改进路线: IMPROVEMENT_ROADMAP.md
       - 数据溯源: MOCK_DATA_POLICY.md
       - 安装部署: DOCKER_INSTALL.md
-      - 审计工作流: audit-workflow.md
       - 引用指南: CITATION_GUIDE.md

--- a/docs/tutorials/02-financial-report.md
+++ b/docs/tutorials/02-financial-report.md
@@ -238,4 +238,4 @@ result = asyncio.run(analyze_stock("000001.SZ"))
 
 - [Tutorial 4: MCP Tool Marketplace](04-mcp-marketplace.md)
 - [Tutorial 5: Event-Driven Research](05-event-driven-research.md)
-- [API Reference: AgentOrchestrator](../api_reference.md#agentorchestrator)
+- [API Reference](../api_reference.md)

--- a/docs/tutorials/04-mcp-marketplace.md
+++ b/docs/tutorials/04-mcp-marketplace.md
@@ -248,5 +248,5 @@ params: { "ts_code": "000001.SZ", "max_results": 20 }
 ## Next Steps
 
 - [Tutorial 5: Event-Driven Research](05-event-driven-research.md)
-- [API Reference: MCPToolRegistry](../api_reference.md#mcptoolregistry)
-- [Setup Guide: MCP Server Configuration](../../SETUP_GUIDE.md)
+- [API Reference](../api_reference.md)
+- [Setup Guide: MCP Server Configuration](https://github.com/csmar432/finai-research/blob/main/SETUP_GUIDE.md)

--- a/docs/tutorials/05-event-driven-research.md
+++ b/docs/tutorials/05-event-driven-research.md
@@ -417,6 +417,6 @@ for event in events:
 
 ## Next Steps
 
-- [API Reference: EventMonitor](../api_reference.md#eventmonitor)
+- [API Reference](../api_reference.md)
 - [Tutorial 2: Financial Research Report](02-financial-report.md)
-- [Setup Guide: MCP Server Configuration](../../SETUP_GUIDE.md)
+- [Setup Guide: MCP Server Configuration](https://github.com/csmar432/finai-research/blob/main/SETUP_GUIDE.md)

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -8,13 +8,13 @@
 > - **Tutorial 1 (快速入门)**: 全中文，是新手必读
 > - **Tutorial 2-5**: 主体英文（因示例代码含较多英文 API/库名，中英混杂影响可读性）
 >
-> 如需中文版本，请参考 [`使用指南.md`](../../使用指南.md) 的对应章节。如发现翻译错误或希望贡献中文版本，欢迎提 PR。
+> 如需中文版本，请参考 [仓库中的使用指南](https://github.com/csmar432/finai-research/blob/main/使用指南.md) 的对应章节。如发现翻译错误或希望贡献中文版本，欢迎提 PR。
 >
 > Tutorials adopt a "**Chinese-first**" policy:
 > - **Tutorial 1 (Quickstart)**: Chinese only — required reading for new users
 > - **Tutorials 2-5**: English-dominant (because example code contains many English APIs; mixed CN/EN hurts readability)
 >
-> For Chinese versions, see [`使用指南.md`](../../使用指南.md). PRs welcome for any translation improvements.
+> For Chinese versions, see the [Chinese guide in the repository](https://github.com/csmar432/finai-research/blob/main/使用指南.md). PRs welcome for any translation improvements.
 
 ---
 
@@ -25,7 +25,7 @@
 | 1 | [快速入门](01-quickstart.md) | 5分钟配置 + 运行第一个研究流程 | 5 分钟 |
 | 2 | [金融研究报告](02-financial-report.md) | 使用脚本生成研报 + 数据获取 | 15 分钟 |
 | 3 | [研究方向设计](03-research-directions.md) | 发现研究想法 + 数据验证 | 20 分钟 |
-| 4 | [MCP 工具市场](04-mcp-marketplace.md) | 41个数据服务器的安装与使用 | 30 分钟 |
+| 4 | [MCP 工具市场](04-mcp-marketplace.md) | 43个数据服务器的安装与使用 | 30 分钟 |
 | 5 | [事件驱动研究](05-event-driven-research.md) | 宏观事件监控 + 自动触发研究 | 30 分钟 |
 
 ---
@@ -77,6 +77,6 @@
 
 遇到问题时：
 
-1. 查看 [FAQ.md](../../FAQ.md)（30 个常见问题）
+1. 查看仓库中的 [FAQ.md](https://github.com/csmar432/finai-research/blob/main/FAQ.md)（30 个常见问题）
 2. 运行 `python scripts/health_check.py --verify` 获取详细诊断
-3. 检查 [.env.example](../../.env.example) 确认 API Key 配置
+3. 检查仓库中的 [.env.example](https://github.com/csmar432/finai-research/blob/main/.env.example) 确认 API Key 配置

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,8 +16,11 @@ docs_dir: docs
 
 # Exclude internal plan documents and legacy files
 exclude_docs: |
+  README.md
+  !tutorials/README.md
   plans/
   论文写作工作流使用指南.md
+  zhihu-publish/
 
 
 theme:
@@ -71,8 +74,9 @@ markdown_extensions:
   - pymdownx.keys
 
 nav:
-  - Home: tutorials/index.md
+  - Home: index.md
   - 快速入门:
+      - 教程总览: tutorials/README.md
       - 安装配置: tutorials/01-quickstart.md
       - 金融研究报告: tutorials/02-financial-report.md
       - 研究方向设计: tutorials/03-research-directions.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,7 +148,7 @@ knowledge = [
 ]
 
 sandbox = [
-    "e2b-code-interpreter>=2.0.0,<2.0",
+    "e2b-code-interpreter>=2.0.0,<3.0",
 ]
 
 browser = [

--- a/requirements-ci-lock.txt
+++ b/requirements-ci-lock.txt
@@ -192,8 +192,9 @@ patsy==1.0.2
     # via statsmodels
 pillow==12.3.0
     # via matplotlib
-pip==26.2
-    # via pip-api
+# `pip` is intentionally not locked here. CI upgrades pip before installing
+# this file; locking it would make Windows try to self-downgrade in the same
+# install transaction and leave the remaining dependencies uninstalled.
 pip-api==0.0.34
     # via pip-audit
 pip-audit==2.10.1

--- a/scripts/PROJECT_NUMBERS.json
+++ b/scripts/PROJECT_NUMBERS.json
@@ -1,13 +1,13 @@
 {
   "$schema": "./project_numbers.schema.json",
   "_comment": "Single Source of Truth for all project metric numbers. All documentation MUST reference these values. Update this file via `python scripts/count_assets.py --sync-ssot`, not by hand. Manually maintained numbers historically drift; auto-generation from disk eliminates the root cause.",
-  "last_verified": "2026-08-03",
+  "last_verified": "2026-08-05",
   "verified_by": "scripts/count_assets.py --sync-ssot",
   "generation_command": "python scripts/count_assets.py --sync-ssot",
   "_manual_overrides": {
     "_comment": "Fields below are NOT auto-detected by count_assets.py and require manual maintenance.",
     "version.github_release": "v1.0.1 (Zenodo DOI 10.5281/zenodo.21262689, archive minted 2026-07-08)",
-    "version.pypi": "not published (planned for v1.1.0)"
+    "version.pypi": "0.2.0a0 (published)"
   },
   "mcp": {
     "total_directories": 43,
@@ -58,7 +58,7 @@
       "arch_diagram_demos",
       "exact_permutation"
     ],
-    "note": "Smoke tests for all 47 modules committed 2026-06-27. Some modules still need deeper numerical tests."
+    "note": "Smoke tests cover 56 of 58 modules. The remaining two demo/algorithm modules are tracked in zero_test_modules and still need dedicated tests."
   },
   "skills": {
     "total": 18,
@@ -105,11 +105,11 @@
     "note": "30 = unique keys in JOURNAL_METADATA dict. TEMPLATES dict has 44 entries with legacy aliases merged into 30 unique templates (see scripts/journal_template.py)."
   },
   "testing": {
-    "test_files": 659,
-    "test_functions": 12688,
+    "test_files": 665,
+    "test_functions": 12700,
     "numerical_correctness_tests": 9,
-    "ci_coverage_gate": 55,
-    "ci_coverage_target": 60,
+    "ci_coverage_gate": 60,
+    "ci_coverage_target": 65,
     "ci_jobs": 7,
     "lock_files": [
       "requirements-lock.txt",
@@ -131,10 +131,10 @@
     "chinese_guide_lines": 1049
   },
   "version": {
-    "pyproject": "0.1.0",
+    "pyproject": "0.2.0a0",
     "github_release": "v1.0.1",
     "github_release_doi": "10.5281/zenodo.21262689",
     "github_release_date": "2026-07-08",
-    "pypi": "not published"
+    "pypi": "0.2.0a0"
   }
 }

--- a/scripts/SCRIPTS_INDEX.md
+++ b/scripts/SCRIPTS_INDEX.md
@@ -13,11 +13,11 @@
 | 📦 Core Modules (`scripts/core/`) | 105 | 核心库（被其他模块导入）|
 | 📊 Research Framework (`scripts/research_framework/`) | 59 | 计量方法模块 |
 | 🧭 Research Directions (`scripts/research_directions/`) | 15 | 研究方向领域 |
-| 🧪 Tests (`tests/`) | 666 | 测试文件 |
+| 🧪 Tests (`tests/`) | 667 | 测试文件 |
 | 🔌 MCP Servers (`mcp_servers/user_*/`) | 43 | MCP 数据源 |
-| **合计（仅 Python 文件）** | **950** | 不含 MCP / docs / tests fixtures |
+| **合计（仅 Python 文件）** | **951** | 不含 MCP / docs / tests fixtures |
 
-> 自动生成于 2026-08-04
+> 自动生成于 2026-08-05
 ---
 
 ## 一、Entry Points · 用户入口
@@ -218,4 +218,4 @@ report_*.py           # 报告生成（小写下划线）
 
 ---
 
-*本索引由 `scripts/SCRIPTS_INDEX.md` 维护，最后更新: 2026-08-04（自动对账）
+*本索引由 `scripts/SCRIPTS_INDEX.md` 维护，最后更新: 2026-08-05（自动对账）


### PR DESCRIPTION
## Summary
- fix the impossible `e2b-code-interpreter` sandbox constraint (`<2.0` → `<3.0`)
- prevent unreviewed MCP 2.x and OpenAI 2.x Dependabot major upgrades until migration suites exist
- fix the MkDocs Makefile invocation and remove stale audit-report navigation
- consolidate and correct the Chinese/English README and documentation navigation
- synchronize repository metrics and script index with the current tree

## Validation
- `python3 scripts/audit_guard.py`: 25/25 checks passed
- focused consistency tests: 36 passed, 2 xfailed
- `mkdocs build --strict -f mkdocs.yml`: passed
- README local-link audit: 100 links checked, 0 missing
- existing remote main CI baseline: all required checks passed on the latest main run

The local full suite was also executed. Its 24 failures were reproduced as optional-dependency/environment failures on this machine (missing DuckDB/yfinance/MCP in the system interpreter and a mixed-path local virtualenv); the repository CI lockfile remains the validation source for the full dependency environment.
