### PR TITLE
fix: make LLM selection explicit and Mock opt-in

### DIFF
--- a/scripts/PROJECT_NUMBERS.json
+++ b/scripts/PROJECT_NUMBERS.json
@@ -106,7 +106,7 @@
   },
   "testing": {
     "test_files": 665,
-    "test_functions": 12700,
+    "test_functions": 12705,
     "numerical_correctness_tests": 9,
     "ci_coverage_gate": 60,
     "ci_coverage_target": 65,

--- a/scripts/agent_pipeline.py
+++ b/scripts/agent_pipeline.py
@@ -114,6 +114,8 @@ class InteractionResult:
     - action_needed: 下一步操作类型
     - questions: 需要询问用户的问题（用于 AI agent 对话交互）
     - limitations: 受限功能清单
+    - options: 可供调用方展示给用户的结构化选项
+    - recommended_option: 推荐选项的 id；Mock 永远不会被设为推荐
     - can_proceed: 是否可以继续研究
     """
     needs_input: bool = False
@@ -123,6 +125,22 @@ class InteractionResult:
     api_keys_to_add: list[dict] = field(default_factory=list)   # [{name, url}]
     fix_steps: list[str] = field(default_factory=list)
     llm_available: bool = True
+    options: list[dict[str, Any]] = field(default_factory=list)
+    recommended_option: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a host-agent-friendly representation of the interaction."""
+        return {
+            "needs_input": self.needs_input,
+            "action_needed": self.action_needed,
+            "questions": self.questions,
+            "limitations": self.limitations,
+            "api_keys_to_add": self.api_keys_to_add,
+            "fix_steps": self.fix_steps,
+            "llm_available": self.llm_available,
+            "options": self.options,
+            "recommended_option": self.recommended_option,
+        }
 
 
 def _get_canvas_url() -> str:
@@ -805,6 +823,9 @@ class AgentPipelineConfig:
     auto_dashboard: bool = True
     output_dir: Any = None
     llm_use_cache: bool = True
+    strict_llm: bool = True
+    allow_mock: bool = False
+    skip_health: bool = False
     # Research direction branch (None = general academic paper)
     direction: str | None = None  # "green_finance", "digital_finance", "carbon_economics", etc.
     # Auto-generate architecture diagrams for PPT use (default off)
@@ -858,9 +879,10 @@ class AgentPipelineResult:
     did_chart_paths: list = field(default_factory=list)
     # 自动生成的架构图路径列表（PPT 用, 仅当 config.auto_arch_diagrams=True）
     arch_diagram_paths: list = field(default_factory=list)
-    # 是否因 LLM 不可用而降级到 MockTemplateEngine（pipeline 已执行但产出物为 mock）
+    # 是否因用户明确授权而使用 MockTemplateEngine（产出物为 mock）
     llm_fallback_used: bool = False
     llm_status: str = ""
+    interaction: InteractionResult | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -868,6 +890,8 @@ class AgentPipelineResult:
                 "topic": self.config.topic,
                 "venue": self.config.venue,
                 "research_field": self.config.research_field,
+                "strict_llm": self.config.strict_llm,
+                "allow_mock": self.config.allow_mock,
             },
             "success": self.success,
             "llm_fallback_used": self.llm_fallback_used,
@@ -886,6 +910,7 @@ class AgentPipelineResult:
             "hitl_approvals": [a.stage for a in (self.hitl_approvals or [])],
             "visualization": str(self.visualization_path) if self.visualization_path else None,
             "errors": self.errors,
+            "interaction": self.interaction.to_dict() if self.interaction else None,
         }
 
 
@@ -1147,6 +1172,7 @@ class AgentPipeline:
         self._gateway = LLMGateway(
             self._memory,
             use_cache=self.config.llm_use_cache,
+            allow_mock=self.config.allow_mock,
         )
 
         # Initialize citation verifier
@@ -1577,59 +1603,64 @@ class AgentPipeline:
         """
         start_time = time.time()
 
+        # Apply safety-relevant overrides before the pre-flight check.  In
+        # particular, an explicit ``allow_mock=True`` must be visible before
+        # deciding whether the run may proceed.
+        if topic:
+            self.config.topic = topic
+        for key, value in kwargs.items():
+            if hasattr(self.config, key):
+                setattr(self.config, key, value)
+
         # ── Pre-flight configuration check ─────────────────────────────────────────
-        # v2.1 改进（2026-07-12）：不要因为 LLM 不可用就 raise 阻断。
-        # 之前的设计在 Claude Code / Codex / Cursor 等 host agent 场景下会阻断整个
-        # pipeline（错误："LLM 不可用，无法进行论文写作和分析"），但这些场景下：
-        #   1. host agent 本身就是 LLM，能提供 LLM 能力（虽然 CLI 进程无法直接调用）
-        #   2. 用户可能用本地 Ollama 但 health_check 网络抖动误报
-        #   3. MockTemplateEngine 仍可生成结构化草稿，至少让 pipeline 跑通落盘
-        # 新行为：降级到 MockTemplateEngine，stderr 显式 [LLM FALLBACK] 提示，
-        #         绝不静默退化（CLAUDE.md 核心原则 #3）。
-        #
-        # v2.2 (2026-07-13): 新增 --strict-llm 行为：未配置 LLM 时直接退出码 4，
-        # 不再静默跑 MockTemplateEngine 并落盘占位文件（PR-1.4）。
+        # 外部 LLM 不可用时，先把选择返回给终端或 host agent：
+        #   1. Codex / Claude Code / Cursor 可以直接接管对话继续推进；
+        #   2. 用户可以配置外部 API 或 Ollama；
+        #   3. Mock 只有在显式 allow_mock 后才可使用，绝不自动降级。
         from scripts.health_check import run_diagnostic
+        _skip_health = bool(getattr(self.config, "skip_health", False))
         try:
-            diag = run_diagnostic()
+            diag = None if _skip_health else run_diagnostic()
         except Exception:
             diag = None
 
-        self._llm_actually_available = bool(diag and diag.llm_available)
+        self._llm_actually_available = True if _skip_health else bool(diag and diag.llm_available)
+        interaction = None
         if not self._llm_actually_available:
-            import sys as _sys
             _reason = (
-                "未配置 DEEPSEEK_API_KEY / RELAY_API_KEY 且 Ollama 未运行。"
+                "未配置可调用的外部 LLM，且 Ollama 未运行。"
                 if diag is None or not diag.llm_status
                 else f"原因：{diag.llm_status[:200]}"
             )
-            # 严格模式（默认开启）下，直接退出 4，避免下游脚本误读 mock 输出。
-            _strict = bool(getattr(self.config, "strict_llm", True))
-            if _strict:
-                print(
-                    "\n⚠️  [LLM FALLBACK] 未配置 LLM，严格模式下退出。\n"
-                    "    \n"
-                    f"    诊断：{_reason}\n"
-                    "    \n"
-                    "    解决方式（任选其一）：\n"
-                    "      1. 在 .env 写入 DEEPSEEK_API_KEY=sk-...\n"
-                    "      2. 运行 `ollama serve` 启用本地模型\n"
-                    "      3. 临时绕过：finai-pipeline --topic '...' （不要加 --strict-llm 关闭；\n"
-                    "         当前已默认开启，不需显式传）\n"
-                    "    \n"
-                    "    说明：Cursor / Claude Code / Codex 等 host agent 本身有 LLM，但 CLI\n"
-                    "    进程无法直接调用它。如需在 host agent 中跑 pipeline，请通过 MCP\n"
-                    "    反向调用或 host agent 端补全 LLM 反馈。\n",
-                    file=_sys.stderr,
-                )
-                return 4
+            interaction = self._check_and_suggest_setup(
+                topic or self.config.topic or "",
+                diag=diag,
+            )
+            self._interaction = interaction
+
+            if not self.config.allow_mock:
+                selected = None
+                if self._is_interactive_terminal():
+                    selected = self._handle_interactive(interaction)
+                if selected != "mock":
+                    return AgentPipelineResult(
+                        config=self.config,
+                        success=False,
+                        errors=[
+                            "未选择可用的 LLM 运行方式；未自动进入 Mock。",
+                            _reason,
+                        ],
+                        total_latency_ms=(time.time() - start_time) * 1000,
+                        llm_status=_reason,
+                        interaction=interaction,
+                    )
+                self.config.allow_mock = True
+
             print(
-                "\n⚠️  [LLM FALLBACK] 本次 pipeline 将降级到 MockTemplateEngine。\n"
-                "    产出物仍可落盘到 output/papers/，但内容是模板（带 [MOCK] 前缀），\n"
-                "    不是真实 LLM 生成。请配置 DEEPSEEK_API_KEY 或运行 `ollama serve`\n"
-                "    后重跑以获得真 LLM 输出。\n"
+                "\n⚠️  已明确授权 Mock 模式：仅用于演示/测试，产出物带 [MOCK] 标记，"
+                "不得作为真实研究结论。\n"
                 f"    诊断：{_reason}\n",
-                file=_sys.stderr,
+                file=sys.stderr,
             )
 
         self._ensure_initialized()
@@ -1731,12 +1762,17 @@ class AgentPipeline:
         # computed earlier in run() so the second health probe in
         # _check_and_suggest_setup doesn't re-run network checks.
         topic_for_check = (topic or self.config.topic or "")
-        ir = self._check_and_suggest_setup(topic_for_check, diag=diag)
+        ir = interaction or (
+            InteractionResult(needs_input=False, action_needed="proceed", llm_available=True)
+            if _skip_health
+            else self._check_and_suggest_setup(topic_for_check, diag=diag)
+        )
+        self._interaction = ir
 
         # 仅在交互式终端中调用 input()（Cursor IDE）
         # Claude Code / Codex 等 AI agent 环境：返回 InteractionResult，
         # 由 AI agent 在对话中向用户询问
-        if self._is_interactive_terminal():
+        if self._is_interactive_terminal() and interaction is None:
             self._handle_interactive(ir)
 
         # ── 可视化延迟启动 ─────────────────────────────────────────────────
@@ -2275,7 +2311,7 @@ class AgentPipeline:
         if self._llm_actually_available:
             _canvas_detail += " | LLM: 可用"
         else:
-            _canvas_detail += " | ⚠️ LLM: Mock 降级（内容为模板，非真实论文）"
+            _canvas_detail += " | ⚠️ LLM: 已授权 Mock（内容为模板，非真实论文）"
         _print_canvas_hint(
             f"研究工作流已完成！({_done_count}/{_total_count} 阶段)",
             _canvas_detail,
@@ -2308,6 +2344,63 @@ class AgentPipeline:
 
         return False
 
+    @staticmethod
+    def _llm_mode_options(platform: str) -> tuple[list[dict[str, Any]], str]:
+        """Build explicit LLM choices for a terminal or host agent.
+
+        The direct-conversation option delegates the next step to the current
+        Codex / Claude Code / Cursor conversation. It is not a fake CLI LLM
+        call, and Mock is deliberately never selected as the recommendation.
+        """
+        host_detected = platform in {"cursor", "claude_code", "codex"}
+        options = [
+            {
+                "id": "host_agent",
+                "label": "当前对话模型直接推进",
+                "description": (
+                    "由 Codex / Claude Code / Cursor 在当前对话中继续，"
+                    "不需要额外 API Key；CLI 不会伪装成已调用外部模型。"
+                ),
+                "recommended": host_detected,
+            },
+            {
+                "id": "external_api",
+                "label": "配置外部 LLM API",
+                "description": "配置 DEEPSEEK_API_KEY 或 RELAY_API_KEY 后由 CLI 调用。",
+                "recommended": not host_detected,
+            },
+            {
+                "id": "ollama",
+                "label": "使用 Ollama 本地模型",
+                "description": "启动 ollama serve 并准备本地模型。",
+                "recommended": False,
+            },
+            {
+                "id": "mock",
+                "label": "Mock 模式（仅演示/测试）",
+                "description": "必须明确选择；输出是模板，不能用于研究结论。",
+                "recommended": False,
+            },
+            {
+                "id": "exit",
+                "label": "退出并补齐配置",
+                "description": "不生成研究产出，修复后重新运行。",
+                "recommended": False,
+            },
+        ]
+        return options, "host_agent" if host_detected else "external_api"
+
+    @staticmethod
+    def _format_options(options: list[dict[str, Any]], recommended: str) -> list[str]:
+        """Format structured options for terminal prompts without losing ids."""
+        lines = []
+        for index, option in enumerate(options, start=1):
+            mark = " ← 推荐" if option["id"] == recommended else ""
+            lines.append(
+                f"  ({index}) {option['label']}{mark} — {option['description']}"
+            )
+        return lines
+
     def _check_and_suggest_setup(
         self,
         topic: str = "",
@@ -2339,15 +2432,41 @@ class AgentPipeline:
         try:
             from scripts.health_check import run_diagnostic, print_diagnostic
         except ImportError:
-            print("⚠️  无法导入 health_check 模块，跳过自检")
-            return InteractionResult(needs_input=False, action_needed="proceed")
+            print("⚠️  无法导入 health_check 模块，等待明确选择")
+            options, recommended = self._llm_mode_options("unknown")
+            return InteractionResult(
+                needs_input=True,
+                action_needed="ask_llm_confirm",
+                questions=[
+                    "无法加载健康检查；不会自动进入 Mock。",
+                    *self._format_options(options, recommended),
+                ],
+                limitations=["健康检查模块不可用"],
+                llm_available=False,
+                options=options,
+                recommended_option=recommended,
+            )
 
         if diag is None:
             try:
                 result = run_diagnostic()
             except Exception as e:
-                print(f"⚠️  健康检查执行失败: {e}，跳过自检继续运行")
-                return InteractionResult(needs_input=False, action_needed="proceed")
+                print(f"⚠️  健康检查执行失败: {e}，等待明确选择")
+                options, recommended = self._llm_mode_options("unknown")
+                return InteractionResult(
+                    needs_input=True,
+                    action_needed="ask_llm_confirm",
+                    questions=[
+                        "健康检查未能完成；不会自动进入 Mock。",
+                        "请选择当前对话模型、外部 API、Ollama、Mock（仅演示/测试）或退出。",
+                        *self._format_options(options, recommended),
+                    ],
+                    limitations=["健康检查失败"],
+                    fix_steps=["重新运行健康检查，或检查本地依赖与网络。"],
+                    llm_available=False,
+                    options=options,
+                    recommended_option=recommended,
+                )
         else:
             result = diag
 
@@ -2398,7 +2517,7 @@ class AgentPipeline:
                 f"检测到 {len(api_key_problems)} 个 API Key 缺失，受限功能：{', '.join(limitations)}。"
                 f" 是否现在补充配置？",
                 "",
-                "  (1) 是 — 我来帮你打开 .env.local 配置",
+                "  (1) 是 — 我来帮你打开 .env.local 配置 ← 推荐",
                 "  (2) 否 — 跳过，使用已有工具继续（部分数据功能受限）",
             ]
             self._limitation_note = "；".join(limitations) if limitations else ""
@@ -2410,22 +2529,38 @@ class AgentPipeline:
                 api_keys_to_add=api_keys_to_add,
                 fix_steps=fix_steps,
                 llm_available=True,
+                options=[
+                    {
+                        "id": "configure_data_api",
+                        "label": "补充数据源 API Key",
+                        "description": "解除受限数据功能。",
+                        "recommended": True,
+                    },
+                    {
+                        "id": "continue_limited",
+                        "label": "跳过并继续",
+                        "description": "继续工作，但缺失数据源相关功能不可用。",
+                        "recommended": False,
+                    },
+                ],
+                recommended_option="configure_data_api",
             )
 
         # ── 情形 C：LLM 不可用 ──────────────────────────────────
+        options, recommended = self._llm_mode_options(getattr(result, "platform", "unknown"))
         questions = [
-            "LLM 不可用，无法进行论文写作和分析。",
+            "未检测到可调用的外部 LLM；不会自动进入 Mock。",
+            "如果当前运行在 Codex / Claude Code / Cursor 中，推荐直接由当前对话模型继续推进。",
             "当前受限功能：",
         ]
         for step in fix_steps[:4]:
             questions.append(f"  {step}")
         questions.extend([
             "",
-            "是否继续？（系统将使用已有工具工作，但无法调用 LLM 生成文本）",
-            "  (1) 继续 — 继续工作（受限模式）",
-            "  (2) 退出 — 修复后重新启动",
+            "请选择后续运行方式：",
+            *self._format_options(options, recommended),
         ])
-        self._limitation_note = "LLM 不可用"
+        self._limitation_note = "LLM 不可用；等待明确选择"
         return InteractionResult(
             needs_input=True,
             action_needed="ask_llm_confirm",
@@ -2433,15 +2568,17 @@ class AgentPipeline:
             limitations=["LLM 不可用"],
             fix_steps=fix_steps,
             llm_available=False,
+            options=options,
+            recommended_option=recommended,
         )
 
-    def _handle_interactive(self, ir: InteractionResult) -> None:
+    def _handle_interactive(self, ir: InteractionResult) -> str | None:
         """终端入口专用：在终端中使用 input() 与用户交互。
 
         此方法仅在脚本直接运行时（而非被 AI agent 调用时）使用。
         """
         if not ir.needs_input:
-            return
+            return "proceed"
 
         print()
         print(bold(cyan("─" * 72)))
@@ -2454,29 +2591,57 @@ class AgentPipeline:
             try:
                 response = input(bold("  你的选择: ")).strip().lower()
             except (EOFError, KeyboardInterrupt):
-                response = "2"
+                response = ""
             print()
 
             if response in ("1", "是", "好", "y", "yes", "ok"):
                 self._do_api_key_setup(ir)
+                return "configure_data_api"
             else:
                 lim = '、'.join(ir.limitations) if ir.limitations else "无"
                 print(f"  {dim('跳过配置，受限功能：' + lim)}")
                 print()
+                return "continue_limited"
 
         elif ir.action_needed == "ask_llm_confirm":
             for q in ir.questions:
-                print(f"  {red(q) if 'LLM 不可用' in q else '  ' + q}")
+                print(f"  {red(q) if 'LLM' in q or 'Mock' in q else '  ' + q}")
             print()
+            recommended = ir.recommended_option or "exit"
+            option_ids = {
+                str(index): option["id"]
+                for index, option in enumerate(ir.options, start=1)
+            }
+            labels = {option["id"]: option["label"] for option in ir.options}
+            recommended_index = next(
+                (
+                    index
+                    for index, option in enumerate(ir.options, start=1)
+                    if option["id"] == recommended
+                ),
+                "5",
+            )
             try:
-                response = input(bold("  你的选择 [默认: 1 继续]: ")).strip().lower()
+                response = input(
+                    bold(f"  你的选择 [默认: {recommended_index}]: ")
+                ).strip().lower()
             except (EOFError, KeyboardInterrupt):
                 print()
-                return
-            if response in ("2", "退出", "no", "n"):
+                return "exit"
+            selected = option_ids.get(response, response or recommended)
+            if selected == "mock":
+                print(f"  {yellow('已明确选择 Mock：仅用于演示/测试，不得作为研究结论。')}")
+                print()
+                return "mock"
+            if selected == "exit" or selected not in labels:
                 print(f"  {dim('退出。请修复 LLM 配置后重新启动。')}")
-                return
+                print()
+                return "exit"
+            print(f"  {dim('已选择：' + labels[selected] + '。请由对应模型/服务继续后再运行流水线。')}")
             print()
+            return selected
+
+        return None
 
     def _do_api_key_setup(self, ir: InteractionResult) -> None:
         """执行 API Key 配置向导（终端）。"""
@@ -3029,9 +3194,14 @@ Examples:
         action=argparse.BooleanOptionalAction,
         default=True,
         help=(
-            "默认开启：未配置 LLM 时直接退出码 4（避免静默跑 MockTemplateEngine 并落盘占位文件）。"
-            "用 --no-strict-llm 关闭，回归到 MockTemplateEngine 降级行为。"
+            "默认开启：未配置 LLM 时返回选择项并停止，不生成占位研究产出。"
+            "--no-strict-llm 只改变失败处理策略，不会授权 Mock。"
         ),
+    )
+    parser.add_argument(
+        "--allow-mock",
+        action="store_true",
+        help="明确授权 Mock 模式（仅演示/测试；不得用于研究结论）。",
     )
     parser.add_argument(
         "--skip-health",
@@ -3096,9 +3266,9 @@ Examples:
         config.venue = args.venue
     if args.use_hitl:
         config.use_hitl = True
-    # v2.2 (2026-07-13): forward strict-llm/skip-health to pipeline config so
-    # PR-1.4 的 exit code 4 行为能正确触发（默认开启）。
+    # Forward LLM safety controls to the pipeline config.
     config.strict_llm = bool(args.strict_llm)
+    config.allow_mock = bool(args.allow_mock)
     if args.skip_health:
         config.skip_health = True
     # v2.3 (2026-08-02): --auto-arch 启用 PLOTTING 阶段后的架构图自动生成
@@ -3108,6 +3278,10 @@ Examples:
     pipeline = AgentPipeline(config=config, use_langgraph=args.langgraph)
     result = pipeline.run(topic=args.topic, output_dir=output_dir)
 
+    interaction = getattr(result, "interaction", None)
+    if interaction and not result.success and not interaction.llm_available:
+        print("\n⚠️  未运行流水线：请先选择一种 LLM 运行方式。")
+        return 4
     if result.success:
         print("\n✅ 流水线执行完成")
         return 0

--- a/scripts/ai_router.py
+++ b/scripts/ai_router.py
@@ -1149,8 +1149,9 @@ class AIRouter:
       4. 记录使用了哪个模型作为最终结果
     """
 
-    def __init__(self, use_cache: bool = True):
+    def __init__(self, use_cache: bool = True, allow_mock: bool = False):
         self._use_cache = use_cache
+        self._allow_mock = allow_mock
         self._pool: ModelPool | None = None
         self._bridge: LLMBridge | None = None
         self._cache: CacheManager | None = None
@@ -1172,13 +1173,15 @@ class AIRouter:
         if os.getenv("OLLAMA_ENABLED", "false").lower() == "true":
             self._ollama = OllamaProvider()
 
-        # MockTemplateEngine（所有后端挂掉时的最终 fallback）
-        try:
-            from scripts.core.mock_template_engine import MockTemplateEngine
-            self._mock_fallback = MockTemplateEngine()
-        except ImportError:
-            self._mock_fallback = None
-            _log.warning("MockTemplateEngine not available, no fallback when all LLMs fail")
+        # MockTemplateEngine is opt-in.  A research run must stop rather than
+        # silently turn a backend outage into a template-looking result.
+        if self._allow_mock:
+            try:
+                from scripts.core.mock_template_engine import MockTemplateEngine
+                self._mock_fallback = MockTemplateEngine()
+            except ImportError:
+                self._mock_fallback = None
+                _log.warning("MockTemplateEngine not available, no fallback when all LLMs fail")
 
         # 检查各模型可用状态
         for key in ModelKey:
@@ -1191,10 +1194,10 @@ class AIRouter:
             else:
                 self._available[key.value] = "❌ 未安装"
 
-        # MockTemplateEngine 始终可用（作为最终 fallback）
         self._available["mock_template"] = (
-            f"✅ mock_template (无 API Key 时兜底)"
-            if self._mock_fallback else "❌ 未安装"
+            "✅ mock_template（已明确启用，仅演示/测试）"
+            if self._mock_fallback
+            else "⛔ 未启用（需显式 allow_mock=True 或 --allow-mock）"
         )
 
         self._initialized = True
@@ -1386,7 +1389,7 @@ class AIRouter:
                     fallback_tried=fallback_tried + ["ollama"],
                 )
 
-        # 全部失败 → MockTemplateEngine 最终 fallback
+        # 全部失败 → only use MockTemplateEngine after explicit opt-in.
         tried_str = " → ".join(fallback_tried)
         if self._mock_fallback is not None:
             _log.warning(
@@ -1421,10 +1424,14 @@ class AIRouter:
                 fallback_tried=fallback_tried + ["mock_template"],
             )
 
-        raise RuntimeError(
+        message = (
             f"所有模型均调用失败（尝试顺序：{tried_str}）。"
-            f"最后错误：{last_error}"
-        ) from last_error
+            f"最后错误：{last_error}. 未自动进入 Mock；"
+            "如仅用于演示/测试，请显式设置 allow_mock=True 或使用 --allow-mock。"
+        )
+        if last_error is None:
+            raise RuntimeError(message)
+        raise RuntimeError(message) from last_error
 
     def clear_cache(self):
         """清空所有缓存。"""
@@ -1441,7 +1448,7 @@ class AIRouter:
 # 便捷别名
 # ═══════════════════════════════════════════════════════════════════════
 
-AI = AIRouter(use_cache=True)
+AI = AIRouter(use_cache=True, allow_mock=False)
 
 
 # ═══════════════════════════════════════════════════════════════════════

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -215,6 +215,11 @@ def pipeline_cmd_wrapper(argv: list[str] | None = None) -> int:
         action="store_true",
         help="无 LLM 时直接退出码 4（默认行为；保留参数以兼容旧脚本）",
     )
+    parser.add_argument(
+        "--allow-mock",
+        action="store_true",
+        help="明确授权 Mock 模式（仅演示/测试；不得用于研究结论）",
+    )
 
     args = parser.parse_args(argv)
 
@@ -255,6 +260,10 @@ def pipeline_cmd_wrapper(argv: list[str] | None = None) -> int:
         forwarded.append("--skip-health")
     if args.interactive:
         forwarded.append("--interactive")
+    if args.strict_llm:
+        forwarded.append("--strict-llm")
+    if args.allow_mock:
+        forwarded.append("--allow-mock")
 
     return pipeline_main(forwarded)
 

--- a/scripts/core/llm_gateway.py
+++ b/scripts/core/llm_gateway.py
@@ -523,7 +523,12 @@ class LLMGateway:
     _call_counter: int = 0
     _counter_lock: threading.Lock = threading.Lock()
 
-    def __init__(self, memory: ResearchMemory, use_cache: bool = True):
+    def __init__(
+        self,
+        memory: ResearchMemory,
+        use_cache: bool = True,
+        allow_mock: bool = False,
+    ):
         """Initialize the gateway.
 
         Parameters
@@ -532,6 +537,9 @@ class LLMGateway:
             The agent's memory instance for logging calls.
         use_cache : bool
             Whether to enable response caching. Default True.
+        allow_mock : bool
+            Explicitly allow MockTemplateEngine for demonstrations/tests.
+            Default False so backend failures are surfaced to the caller.
         """
         # Use importlib.import_module (NOT ``import x as y``) so we always
         # look up ``scripts.ai_router`` via sys.modules, even when the
@@ -544,7 +552,13 @@ class LLMGateway:
 
         self.memory = memory
         self._use_cache = use_cache
-        self.router = importlib.import_module("scripts.ai_router").AI
+        router_module = importlib.import_module("scripts.ai_router")
+        self._allow_mock = allow_mock
+        self.router = (
+            router_module.AIRouter(use_cache=use_cache, allow_mock=True)
+            if allow_mock
+            else router_module.AI
+        )
         self.stats = CostStats()
 
         # Ensure router cache is consistent with our use_cache setting

--- a/scripts/core/mock_template_engine.py
+++ b/scripts/core/mock_template_engine.py
@@ -1,4 +1,4 @@
-"""MockTemplateEngine — last-resort fallback when all LLM backends fail.
+"""MockTemplateEngine — explicit opt-in templates for demos and tests.
 
 PR3 (Audit 2026-06-27).
 
@@ -15,7 +15,7 @@ PR3 (Audit 2026-06-27).
   result = engine.generate("outline", topic="碳排放权交易与绿色创新", venue="经济研究")
   print(result.content)   # 结构化大纲
 
-  # 作为 AIRouter 的最终 fallback：
+  # 作为 AIRouter 的显式最终 fallback（需 allow_mock=True）：
   result = ai_router.chat(...)
   if result.model_used == "mock_template":
       print("⚠️  无 LLM 后端，使用模板生成")
@@ -347,7 +347,7 @@ python scripts/agent_pipeline.py --topic "{topic or '[TOPIC]'}"
 
 
 def _register_mock_template_fallback(router) -> None:
-    """将 MockTemplateEngine 注册为 AIRouter 的最终 fallback。
+    """将 MockTemplateEngine 显式注册为 AIRouter 的最终 fallback。
 
     在 ai_router.py 的 AIRouter 实例化后调用此函数。
     修改 router._mock_fallback_engine 引用。

--- a/scripts/health_check.py
+++ b/scripts/health_check.py
@@ -199,7 +199,9 @@ def _detect_platform() -> str:
         os.environ.get("VSCODE_RESOLVING_ENVIRONMENT", "") +
         os.environ.get("CLAUDE_CODE", "") +
         os.environ.get("AGENT_ID", "") +
-        os.environ.get("CODALANG_AGENT", "")
+        os.environ.get("CODALANG_AGENT", "") +
+        os.environ.get("CODEX_THREAD_ID", "") +
+        os.environ.get("CODEX_INTERNAL_ORIGINATOR_OVERRIDE", "")
     )
     env_lower = env_str.lower()
     if "cursor" in env_lower:
@@ -505,11 +507,9 @@ def _check_llm(verify: bool = False) -> tuple[bool, str, list[ProblemItem]]:
     except Exception:
         pass
 
-    # ── Host Agent 委托检测（v2.1: Cursor / Claude Code / Codex）──────────────
-    # 注意：这里仅记录到 problems 作为 information-level 警告，**不**进入 available。
-    # 因为 CLI 进程无法直接调用 host agent 的 LLM；检测到 host agent 不等于
-    # LLM 真的可用。pipeline.run 在 llm_available=False 时会降级到
-    # MockTemplateEngine，host agent 端可看到 [MOCK] 草稿并补全。
+    # ── Host Agent 委托检测（Cursor / Claude Code / Codex）──────────────────
+    # CLI 进程不能伪造对 host agent 的调用，但 host agent 可以在当前对话中
+    # 直接接管后续步骤。这里必须明确告知这一选项，不能把它描述成 Mock 降级。
     host_platform = _detect_platform()
     if host_platform in ("cursor", "claude_code", "codex"):
         problems.append(ProblemItem(
@@ -518,14 +518,16 @@ def _check_llm(verify: bool = False) -> tuple[bool, str, list[ProblemItem]]:
             name_zh="Host Agent 上下文",
             message=(
                 f"检测到 host agent: {host_platform}。"
-                "CLI 进程无法直接调用 host agent 的 LLM；"
-                "pipeline 将降级到 MockTemplateEngine。"
-                "如需真 LLM，请配置 DEEPSEEK_API_KEY 或运行 ollama serve。"
+                "CLI 进程不会直接调用 host agent 的 LLM；"
+                "可由当前 Codex / Claude Code / Cursor 对话模型继续推进，"
+                "也可选择配置外部 API 或 Ollama。系统不会自动进入 Mock。"
             ),
             fix_steps=[
-                "1. 配置 DEEPSEEK_API_KEY（推荐）— 见 .env.example",
-                "2. 或运行 `ollama serve` 启动本地模型",
-                "3. 或接受 [MOCK] 草稿 — host agent 端可看到并补全内容",
+                "【推荐】1. 由当前 Codex / Claude Code / Cursor 对话模型直接继续，无需额外 API Key",
+                "2. 配置 DEEPSEEK_API_KEY 或 RELAY_API_KEY 供 CLI 调用",
+                "3. 运行 `ollama serve` 启动本地模型",
+                "4. 仅在演示/测试中明确选择 Mock；Mock 结果不可用于研究结论",
+                "5. 退出并补齐配置后重新运行",
             ],
             severity="low",
         ))
@@ -1042,6 +1044,11 @@ def run_diagnostic(
 
     # 7. 建议
     recs: list[str] = []
+    if not llm_available and platform in ("cursor", "claude_code", "codex"):
+        recs.append(
+            "【推荐】当前对话模型（Codex / Claude Code / Cursor）可直接继续；"
+            "CLI 不会自动转入 Mock。"
+        )
     if not llm_available:
         high_sev = [p for p in all_problems if p.severity == "high"]
         if high_sev:

--- a/scripts/keychain_manager.py
+++ b/scripts/keychain_manager.py
@@ -10,9 +10,9 @@
     api_key = get_secret("DEEPSEEK_API_KEY")  # 可返回空字符串
     if not api_key:
         # 在 host agent (Cursor/Claude Code/Codex) 模式下，
-        # host agent 本身有 LLM，pipeline 会降级到 MockTemplateEngine。
+        # host agent 本身可以在当前对话中继续；CLI 不会自动进入 Mock。
         # 这里仅记录到日志，不再 raise。
-        logger.warning("DEEPSEEK_API_KEY 未配置，将使用 host agent 或 MockTemplateEngine")
+        logger.warning("DEEPSEEK_API_KEY 未配置，可由 host agent 对话继续或配置外部 LLM")
 
 环境：
   macOS   — 使用 security CLI (需要 scripts.keychain_setup 先注册)

--- a/scripts/setup_wizard.py
+++ b/scripts/setup_wizard.py
@@ -220,8 +220,7 @@ DIRECTION_REQUIREMENTS: dict[str, DirectionConfig] = {
         # v2.1 (2026-07-12): DEEPSEEK_API_KEY 改为 recommended 而非 required。
         # 理由：在 Cursor/Claude Code/Codex 等 host agent 中运行时，
         #       host agent 本身就是 LLM（虽然 CLI 进程无法直接调用）。
-        #       缺少 DEEPSEEK 时 pipeline 会降级到 MockTemplateEngine，
-        #       产出 [MOCK] 草稿而非崩溃。
+        #       缺少 DEEPSEEK 时可由 host agent 对话继续；CLI 不会自动进入 Mock。
         required=[],
         recommended=["DEEPSEEK_API_KEY", "TUSHARE_TOKEN", "RELAY_API_KEY"],
         nice=["BRAVE_SEARCH_API_KEY", "OLLAMA_ENABLED"],

--- a/tests/test_agent_pipeline_unit.py
+++ b/tests/test_agent_pipeline_unit.py
@@ -3,6 +3,8 @@ Unit tests for scripts/agent_pipeline.py — dataclasses and helper functions.
 """
 import sys
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
@@ -22,6 +24,8 @@ class TestInteractionResultDataclass:
         assert result.api_keys_to_add == []
         assert result.fix_steps == []
         assert result.llm_available is True
+        assert result.options == []
+        assert result.recommended_option == ""
 
     def test_interaction_result_with_api_key_issues(self):
         from scripts.agent_pipeline import InteractionResult
@@ -52,6 +56,61 @@ class TestInteractionResultDataclass:
         )
         assert result.llm_available is False
         assert result.action_needed == "ask_llm_confirm"
+
+    def test_interaction_result_serializes_options(self):
+        from scripts.agent_pipeline import InteractionResult
+
+        result = InteractionResult(
+            needs_input=True,
+            action_needed="ask_llm_confirm",
+            options=[{"id": "host_agent", "recommended": True}],
+            recommended_option="host_agent",
+        )
+        payload = result.to_dict()
+        assert payload["recommended_option"] == "host_agent"
+        assert payload["options"][0]["id"] == "host_agent"
+
+
+class TestLLMModeSelection:
+    def test_host_agent_is_recommended_without_mock(self):
+        from scripts.agent_pipeline import AgentPipeline
+
+        options, recommended = AgentPipeline._llm_mode_options("codex")
+        assert recommended == "host_agent"
+        assert next(item for item in options if item["id"] == "host_agent")["recommended"] is True
+        assert next(item for item in options if item["id"] == "mock")["recommended"] is False
+
+    def test_external_api_is_recommended_outside_host_agent(self):
+        from scripts.agent_pipeline import AgentPipeline
+
+        options, recommended = AgentPipeline._llm_mode_options("unknown")
+        assert recommended == "external_api"
+        assert {item["id"] for item in options} == {
+            "host_agent", "external_api", "ollama", "mock", "exit",
+        }
+
+    def test_pipeline_returns_choices_instead_of_entering_mock(self):
+        from scripts.agent_pipeline import AgentPipeline, AgentPipelineConfig, InteractionResult
+
+        diag = SimpleNamespace(llm_available=False, llm_status="no external LLM")
+        interaction = InteractionResult(
+            needs_input=True,
+            action_needed="ask_llm_confirm",
+            llm_available=False,
+            options=[{"id": "host_agent", "recommended": True}],
+            recommended_option="host_agent",
+        )
+        pipeline = AgentPipeline(AgentPipelineConfig(topic="test"))
+        with patch("scripts.health_check.run_diagnostic", return_value=diag), \
+             patch.object(pipeline, "_check_and_suggest_setup", return_value=interaction), \
+             patch.object(pipeline, "_is_interactive_terminal", return_value=False):
+            result = pipeline.run(topic="carbon test")
+
+        assert result.success is False
+        assert result.interaction is interaction
+        assert result.interaction.recommended_option == "host_agent"
+        assert result.config.topic == "carbon test"
+        assert pipeline._gateway is None
 
 
 class TestPipelineConfigurationError:

--- a/tests/test_pr3_llm.py
+++ b/tests/test_pr3_llm.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 
 from scripts.core.mock_template_engine import (
@@ -128,8 +130,8 @@ def test_content_contains_no_hallucinated_data():
 # ─── AIRouter Integration Test ──────────────────────────────────────────────────
 
 
-def test_airouter_initializes_mock_fallback():
-    """AIRouter 初始化后应有 _mock_fallback 属性。"""
+def test_airouter_mock_fallback_is_opt_in():
+    """AIRouter must not enable Mock unless the caller explicitly opts in."""
     from scripts.ai_router import AIRouter
     router = AIRouter(use_cache=False)
 
@@ -137,8 +139,11 @@ def test_airouter_initializes_mock_fallback():
     router._lazy_init()
 
     assert hasattr(router, "_mock_fallback"), "AIRouter should have _mock_fallback attribute"
-    # mock_fallback 可以是 None（如果导入失败）或 MockTemplateEngine
-    # 两者都是合法状态
+    assert router._mock_fallback is None
+
+    allowed = AIRouter(use_cache=False, allow_mock=True)
+    allowed._lazy_init()
+    assert allowed._mock_fallback is not None
 
 
 def test_airouter_status_includes_mock():
@@ -147,15 +152,16 @@ def test_airouter_status_includes_mock():
     router = AIRouter(use_cache=False)
     status = router.status()
 
-    # status 应该有 mock_template 条目
+    # status should expose the explicit opt-in state
     assert "mock_template" in status, f"Expected 'mock_template' in status keys: {list(status.keys())}"
+    assert "未启用" in status["mock_template"]
 
 
 # ─── Smoke Test: End-to-end via AIRouter ──────────────────────────────────────
 
 
-def test_airouter_chat_uses_mock_when_all_backends_fail():
-    """当所有后端都不可用时，AIRouter 应返回 mock_template 内容。"""
+def test_airouter_chat_uses_mock_only_when_explicitly_allowed():
+    """当所有后端都不可用时，Mock 必须由调用方明确授权。"""
     import os
     # 若存在任何 LLM key，跳过（因为可能实际调用成功，而非 mock）
     has_key = any([
@@ -168,7 +174,7 @@ def test_airouter_chat_uses_mock_when_all_backends_fail():
 
     from scripts.ai_router import AIRouter
 
-    router = AIRouter(use_cache=False)
+    router = AIRouter(use_cache=False, allow_mock=True)
     result = router.chat(
         "生成一个关于碳排放权交易的论文大纲",
         task="paper_cn",
@@ -185,3 +191,17 @@ def test_airouter_chat_uses_mock_when_all_backends_fail():
     if result.model_used == "mock_template":
         assert "[MOCK" in result.response
         assert len(result.response) > 50
+
+
+def test_airouter_does_not_auto_mock_when_backends_fail():
+    """Default routing must surface backend failure instead of returning a template."""
+    from scripts.ai_router import AIRouter
+
+    router = AIRouter(use_cache=False)
+    router._lazy_init()
+    router._ollama = None
+    with pytest.raises(RuntimeError, match="未自动进入 Mock"):
+        with patch.object(
+            router.bridge, "call", side_effect=RuntimeError("backend down")
+        ):
+            router.chat("生成一个测试大纲", task="paper_cn")

--- a/tests/test_pr6_smoke.py
+++ b/tests/test_pr6_smoke.py
@@ -65,7 +65,7 @@ def test_pr3_mock_template_engine():
 def test_pr3_airouter_has_mock_fallback():
     from scripts.ai_router import AIRouter
 
-    router = AIRouter(use_cache=False)
+    router = AIRouter(use_cache=False, allow_mock=True)
     router._lazy_init()
     assert hasattr(router, "_mock_fallback")
     assert router._mock_fallback is not None


### PR DESCRIPTION
## Summary

- expose direct conversational continuation via Codex / Claude Code / Cursor as a structured LLM option
- mark a context-appropriate LLM choice as recommended
- prevent automatic MockTemplateEngine fallback in AIRouter and AgentPipeline
- add explicit `allow_mock` / `--allow-mock` opt-in for demos and tests
- return structured interaction choices to non-interactive host agents

## Validation

- targeted regression: 111 passed, 1 skipped
- ruff check on changed Python files: passed
- full local suite: 12,834 passed, 196 skipped, 24 failures caused by missing local optional dependencies (`mcp`, `duckdb`, and the mixed Python environment), not by this change
- audit guard: 24/25; the only failure was the existing local numerical-test import environment

User-owned image changes were intentionally left unstaged.
