### PR TITLE
fix: repair pipeline entry, HITL, and setup UX gaps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,8 +35,13 @@ pip install 'finai-research-workflow[extras]'  # from PyPI
 cp .env.example .env.local
 # Edit .env.local: set DEEPSEEK_API_KEY=sk-...
 
-# 3. Run
-python scripts/agent_pipeline.py --topic "Carbon trading and green innovation"
+# 3. Run (pick one path)
+# 3a. Clarify first (recommended for new topics; does not auto-run writing)
+python scripts/start_research.py --topic "Carbon trading and green innovation"
+# optional: python scripts/start_research.py --topic "..." --continue --use-hitl
+
+# 3b. Direct writing pipeline
+python scripts/agent_pipeline.py --topic "Carbon trading and green innovation" --use-hitl
 ```
 
 ---
@@ -56,6 +61,8 @@ Stage 8: Review              → scripts/core/llm_reviewer.py
 ```
 
 Each stage requires user confirmation (HITL). Do NOT auto-continue past a stage.
+`--use-hitl` enables outline/literature/draft gates by default. `InteractivePipelineCheckpoint`
+is for skills/manual import only — not auto-wired into `agent_pipeline`.
 
 ---
 
@@ -64,11 +71,12 @@ Each stage requires user confirmation (HITL). Do NOT auto-continue past a stage.
 | I want to... | Run this |
 |---|---|
 | Check system health | `python scripts/health_check.py` |
-| Run full pipeline | `python scripts/agent_pipeline.py --topic "..."` |
+| Clarify topic (5 rounds) | `python scripts/start_research.py --topic "..."` |
+| Run full pipeline | `python scripts/agent_pipeline.py --topic "..." --use-hitl` |
 | Generate paper draft | `python scripts/research_framework/report_generator.py --outline FILE.md` |
 | Run a specific method (DID/IV/RDD/PSM) | `python scripts/research_framework/modern_did.py --help` |
 | List journal templates | `python scripts/journal_template.py --list` |
-| List MCP servers | `python scripts/register_mcp_servers.py --list` |
+| List / register MCP servers | `python scripts/register_mcp_servers.py --list` / `--profile academic --prune` |
 | Verify project integrity | `python scripts/audit_guard.py` (17/17 checks) |
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,14 @@ pytest tests/ -v
         ↓
 ⑤ 等待研究方向 → 用户描述 → 开始研究
         ↓
-⑥ 推荐入口：python scripts/start_research.py --topic "..."（5 轮渐进式澄清）
+⑥ 推荐路径（两条，勿混用文档死链）：
+     · 新用户澄清：python scripts/start_research.py --topic "..."
+       （锁定 research_profile.json；默认不自动开跑）
+       可选：加 --continue --use-hitl 进入写作流水线
+     · 直接写作：python scripts/agent_pipeline.py --topic "..." [--use-hitl]
+       （--use-hitl 默认停 outline/literature/draft）
+     · HITL：agent_pipeline 的 HITLGate；InteractivePipelineCheckpoint
+       仅供技能/脚本手动 import，不自动挂入主流水线
 ```
 
 **第一步问候是强制要求**，不要跳过。直接开始工作会显得突兀。

--- a/README.md
+++ b/README.md
@@ -29,16 +29,18 @@ pip install "finai-research-workflow[extras]"
 # 配置 LLM（DeepSeek 直连，免费）
 export DEEPSEEK_API_KEY=sk-xxxx
 
-# 启动流水线（wheel 安装后的推荐入口）
-finai-pipeline --topic "Carbon trading and green innovation"
+# 启动流水线（wheel 安装后的写作入口；加 --use-hitl 启用阶段门控）
+finai-pipeline --topic "Carbon trading and green innovation" --use-hitl
 # 或
-python -m finai.pipeline --topic "碳排放权交易与企业绿色创新"
+python -m finai.pipeline --topic "碳排放权交易与企业绿色创新" --use-hitl
 
 # ── 源码安装（推荐贡献者 / 想改代码的用户）────────────────────────────
 git clone https://github.com/csmar432/finai-research.git && cd finai-research
 pip install -e ".[extras]"
-export DEEPSEEK_API_KEY=sk-xxxx
-python scripts/agent_pipeline.py --topic "Carbon trading and green innovation"
+cp .env.example .env.local   # 编辑 .env.local：DEEPSEEK_API_KEY=sk-...
+# 新用户：先澄清（不自动开跑）→ 再写作；或澄清时加 --continue
+python scripts/start_research.py --topic "Carbon trading and green innovation"
+python scripts/agent_pipeline.py --topic "Carbon trading and green innovation" --use-hitl
 
 # ── Debian/Ubuntu apt 系统 Python ─────────────────────────────────────
 # apt 的 Python 被系统管理，直接 pip install 会触发 PEP 668 冲突。

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -12,11 +12,13 @@ This document describes the two distinct orchestrator systems in the codebase an
 >
 > | CLI | 用途 | 模块 |
 > |-----|------|------|
-> | `python scripts/start_research.py --topic "..."` | 5 轮渐进式主题澄清入口 | `scripts/start_research.py` |
-> | `python scripts/agent_pipeline.py --topic "..."` | 端到端研究流水线（主题→论文 PDF） | `scripts/agent_pipeline.py` |
+> | `python scripts/start_research.py --topic "..."` | 5 轮渐进式主题澄清（默认只锁画像；`--continue` 才进写作） | `scripts/start_research.py` |
+> | `python scripts/agent_pipeline.py --topic "..." [--use-hitl]` | 端到端研究流水线（主题→论文 PDF） | `scripts/agent_pipeline.py` |
 > | `python scripts/agent.py --task "..."` | 单任务智能体入口（轻量级） | `scripts/agent.py` |
 >
-> README 主推 `start_research.py` 作为新用户入口.
+> **推荐路径**：新用户先 `start_research.py` 澄清 → 再 `agent_pipeline.py --use-hitl`；
+> 或澄清时加 `--continue --use-hitl`。批处理可直接跑 `agent_pipeline`。
+> `InteractivePipelineCheckpoint` 不自动挂入主流水线（技能/手动 import）。
 
 ---
 

--- a/scripts/agent_pipeline.py
+++ b/scripts/agent_pipeline.py
@@ -1111,7 +1111,7 @@ class AgentPipeline:
                         print(f"       缺失: {g}")
             print()
 
-        # 数据缺口的想法：询问用户
+        # 数据缺口 / 需授权：TTY 真问；非 TTY fail-closed（不默默丢掉缺口）
         if gap:
             print("\033[91m" + "  ❌ 有数据缺口的想法（需补充数据或跳过）:" + "\033[0m")
             for idea in gap:
@@ -1122,11 +1122,7 @@ class AgentPipeline:
                     for action in result.actions[:3]:
                         print(f"       → {action}")
             print()
-            print("  提示: 请在 data/ 目录补充所需数据文件，或更换研究方向")
-            print("  如需授权使用演示数据，请调用: checker.authorize_variable('{var_name}')")
-            print()
 
-        # 需授权的想法
         if auth_needed:
             print("\033[93m" + "  🔐 需要模拟数据授权的想法:" + "\033[0m")
             for idea in auth_needed:
@@ -1134,8 +1130,37 @@ class AgentPipeline:
                 print(f"     • {title}")
             print()
 
-        # 最终合并：可行 + 部分可行
         validated = available + partial
+        blocked = gap or auth_needed
+        if blocked:
+            if self._is_interactive_terminal():
+                print("  选项：1) 跳过缺口/需授权想法，仅用可行+部分可行继续")
+                print("        2) 停止流水线，先补充数据或更换方向")
+                try:
+                    choice = input("  你的选择 [1/2，默认 2]: ").strip() or "2"
+                except (EOFError, KeyboardInterrupt):
+                    choice = "2"
+                if choice not in ("1", "是", "y", "yes", "skip"):
+                    print("\033[91m  已停止：存在数据缺口/未授权模拟数据\033[0m")
+                    self._validated_ideas = []
+                    return []
+            else:
+                self._interaction = InteractionResult(
+                    needs_input=True,
+                    action_needed="ask_idea_data",
+                    questions=[
+                        f"有 {len(gap)} 个想法存在数据缺口、{len(auth_needed)} 个需模拟数据授权。"
+                        "请补充 data/、授权模拟数据后重试，或在 TTY 下选择跳过缺口。",
+                    ],
+                    limitations=["idea_data_gap", "idea_auth_needed"],
+                    llm_available=True,
+                )
+                print(
+                    "\033[91m  ⚠ Agent/非 TTY：存在数据缺口或需授权，已停止自动继续"
+                    "（请宿主向用户确认后重试）\033[0m"
+                )
+                self._validated_ideas = []
+                return []
 
         print("\033[96m" + "─" * 60 + "\033[0m")
         print(f"  最终通过验证的想法: {len(validated)}/{len(ideas)}个")
@@ -1769,11 +1794,39 @@ class AgentPipeline:
         )
         self._interaction = ir
 
-        # 仅在交互式终端中调用 input()（Cursor IDE）
-        # Claude Code / Codex 等 AI agent 环境：返回 InteractionResult，
-        # 由 AI agent 在对话中向用户询问
-        if self._is_interactive_terminal() and interaction is None:
-            self._handle_interactive(ir)
+        # 交互式终端：input()；Agent/非 TTY：needs_input 时 fail-closed（不静默继续）
+        # interaction 非 None 表示 LLM 预检块已处理过，勿重复拦截（例如已选 mock）
+        _setup_already_handled = interaction is not None
+        if self._is_interactive_terminal() and not _setup_already_handled:
+            selected = self._handle_interactive(ir)
+            if selected == "exit":
+                return AgentPipelineResult(
+                    config=self.config,
+                    success=False,
+                    errors=["用户取消或未选择可用的 LLM/配置路径。"],
+                    total_latency_ms=(time.time() - start_time) * 1000,
+                    interaction=ir,
+                )
+        elif ir.needs_input and not _setup_already_handled:
+            # Agent 宿主必须读取 interaction.questions 并向用户转述；此处停止推进
+            qs = "; ".join(ir.questions) if ir.questions else ir.action_needed
+            print(
+                f"\n⚠️  需要用户确认（非 TTY / Agent 模式，已停止自动继续）:\n"
+                f"   action={ir.action_needed}\n"
+                f"   {qs}\n"
+                f"   limitations={ir.limitations or []}\n",
+                file=sys.stderr,
+            )
+            return AgentPipelineResult(
+                config=self.config,
+                success=False,
+                errors=[
+                    f"InteractionResult.needs_input=True ({ir.action_needed}); "
+                    "host agent must ask the user before retrying.",
+                ],
+                total_latency_ms=(time.time() - start_time) * 1000,
+                interaction=ir,
+            )
 
         # ── 可视化延迟启动 ─────────────────────────────────────────────────
         # 可视化服务器在用户首个 HITL gate 触发后才启动。
@@ -2320,28 +2373,17 @@ class AgentPipeline:
         return result
 
     def _is_interactive_terminal(self) -> bool:
-        """判断是否在交互式终端中运行（而非被 AI agent 调用）。
+        """判断是否可安全调用 input()。
 
-        只有 Cursor IDE 的终端（或有 TTY 的本地 shell）才进行 input() 交互。
-        Claude Code / Codex 通过对话交互，不调用 input()。
+        有 TTY 的本地 shell（含 Cursor 终端、纯终端）→ True。
+        无 TTY 的 Agent 宿主（Claude Code / Codex / Cursor Agent）→ False，
+        由 InteractionResult 交宿主对话询问（fail-closed，不静默继续）。
         """
-        # 优先用平台检测
         try:
-            from scripts.core.platform import get_platform_info
-            info = get_platform_info()
-            if not info.is_cursor:
-                return False
-        except Exception:  # noqa: S110  # pipeline must not crash on optional feature failures
-            pass
-
-        # 备用：检查是否有 TTY
-        try:
-            import sys
             if hasattr(sys.stdin, "isatty") and sys.stdin.isatty():
                 return True
-        except Exception:  # noqa: S110  # pipeline must not crash on optional feature failures
+        except Exception:  # noqa: S110
             pass
-
         return False
 
     @staticmethod
@@ -2680,7 +2722,7 @@ class AgentPipeline:
                 continue
 
         if not opened:
-            print(f"  {dim('请手动打开: ' + env_hint)}")
+            print(f"  {dim('请手动打开: ' + str(env_file))}")
 
         print()
         print(f"  {dim('配置完成并重启后，下次运行会自动识别')}")
@@ -3167,7 +3209,13 @@ Examples:
     )
     parser.add_argument(
         "--use-hitl", action="store_true",
-        help="启用 Human-in-the-Loop 审批门",
+        help="启用 Human-in-the-Loop 审批门（默认停在 outline/literature/draft）",
+    )
+    parser.add_argument(
+        "--hitl-stages",
+        type=str,
+        default=None,
+        help="逗号分隔的 HITL 阶段（默认 outline,literature,draft；需同时 --use-hitl）",
     )
     parser.add_argument(
         "--language", choices=["zh", "en"], default="zh",
@@ -3266,6 +3314,10 @@ Examples:
         config.venue = args.venue
     if args.use_hitl:
         config.use_hitl = True
+        if args.hitl_stages:
+            config.hitl_stages = [s.strip() for s in args.hitl_stages.split(",") if s.strip()]
+        else:
+            config.hitl_stages = ["outline", "literature", "draft"]
     # Forward LLM safety controls to the pipeline config.
     config.strict_llm = bool(args.strict_llm)
     config.allow_mock = bool(args.allow_mock)

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -196,7 +196,13 @@ def pipeline_cmd_wrapper(argv: list[str] | None = None) -> int:
         help="目标期刊",
     )
     parser.add_argument("--langgraph", action="store_true", help="使用 LangGraph 编排")
-    parser.add_argument("--use-hitl", action="store_true", help="启用人工干预检查点")
+    parser.add_argument("--use-hitl", action="store_true", help="启用人工干预检查点（默认 outline/literature/draft）")
+    parser.add_argument(
+        "--hitl-stages",
+        type=str,
+        default=None,
+        help="逗号分隔 HITL 阶段（需同时 --use-hitl）",
+    )
     parser.add_argument("--language", choices=["zh", "en"], default="zh", help="输出语言")
     parser.add_argument("--output-dir", default="./output", help="输出目录")
     parser.add_argument("--novelty-check", action="store_true", help="强制做新颖性检查")
@@ -254,6 +260,8 @@ def pipeline_cmd_wrapper(argv: list[str] | None = None) -> int:
         forwarded.append("--langgraph")
     if args.use_hitl:
         forwarded.append("--use-hitl")
+    if args.hitl_stages:
+        forwarded.extend(["--hitl-stages", args.hitl_stages])
     if args.novelty_check:
         forwarded.append("--novelty-check")
     if args.skip_health:

--- a/scripts/core/data_gate.py
+++ b/scripts/core/data_gate.py
@@ -78,10 +78,10 @@ class DataGateResult:
                 lines.append(f"    ⚠️  {w}")
         if self.mock_ratio > 0:
             lines.append(f"\n  🚨 警告：{self.mock_ratio*100:.0f}% 为模拟数据！")
-        lines.append("\n  解决方案：")
-        lines.append("    ① 补充缺失数据：python scripts/research_framework/data_fetcher.py")
-        lines.append("    ② 授权使用模拟数据（仅演示）：添加 --allow-synthetic")
-        lines.append("    ③ 更换数据来源：修改 REFINED_DESIGN.md 中的数据源配置")
+        lines.append("\n  解决方案（输入编号）：")
+        lines.append("    1) 补充缺失数据后重试（打印获取命令）")
+        lines.append("    2) 授权使用模拟数据（仅演示，写入 authorized_synthetic.json）")
+        lines.append("    3) 退出，保留会话（可 --resume）")
         return "\n".join(lines)
 
 
@@ -197,11 +197,23 @@ class DataGate:
                 if data_files:
                     warnings.append("缺少 provenance_ids.json（建议在数据获取后生成）")
 
+        auth_path = self.session_dir / "authorized_synthetic.json"
+        synthetic_authorized = auth_path.exists()
+
         is_ready = len(missing) == 0
-        # mock 数据比例 > 0 → 数据不安全，禁止进入写作
+        # mock 数据比例 > 0 → 默认禁止写作；若用户已写授权标记则放行并告警
         if mock_ratio > 0:
-            is_ready = False
-            warnings.insert(0, f"检测到 {mock_ratio*100:.0f}% 模拟数据，数据未就绪")
+            if synthetic_authorized:
+                warnings.insert(
+                    0,
+                    f"检测到约 {mock_ratio*100:.0f}% 模拟数据，但已存在 authorized_synthetic.json（仅演示）",
+                )
+            else:
+                is_ready = False
+                warnings.insert(0, f"检测到 {mock_ratio*100:.0f}% 模拟数据，数据未就绪")
+        elif synthetic_authorized and not is_ready:
+            # 缺失必需文件仍不放行；授权只解除 mock 阻断
+            warnings.append("已授权模拟数据，但仍缺少必需门控文件")
         # FULL 模式下变量冗余不足 → 未就绪
         if self.level == DataGateLevel.FULL:
             var_file = self.session_dir / "redundant_variables.json"
@@ -253,13 +265,26 @@ class DataGate:
 
         if choice == "1":
             print("\n  💡 请运行数据获取：")
-            print(f"    python scripts/research_framework/data_fetcher.py")
+            print("    python scripts/universal_data_fetcher.py --help")
             print(f"    python scripts/start_research.py --resume --session-dir {self.session_dir}")
         elif choice == "2":
-            print("\n  ⚠️  你选择了使用模拟数据继续（仅用于演示）")
+            auth_path = self.session_dir / "authorized_synthetic.json"
+            auth_path.parent.mkdir(parents=True, exist_ok=True)
+            auth_path.write_text(json.dumps({
+                "authorized_at": time.time(),
+                "authorized_via": "DataGate.prompt_user choice=2",
+                "warnings_acknowledged": result.warnings,
+                "mock_ratio": result.mock_ratio,
+                "warning": "⚠️ 任何下游使用此标记生成的论文不能用于发表",
+            }, ensure_ascii=False, indent=2))
+            print("\n  ⚠️  已授权使用模拟数据（仅演示）→", auth_path)
             print("  ⚠️  生成的论文将包含模拟数字，不能用于发表")
+            # 重新检查：mock 阻断可被授权解除；缺失必需文件仍会挡住
+            return self.check()
         elif choice == "3":
             print("\n  退出，当前会话保留在磁盘（可 resume）")
+        else:
+            print("\n  未识别的选项，保持未就绪状态")
         return result
 
     def _save_gate_result(self, result: DataGateResult) -> None:

--- a/scripts/core/progressive_clarifier.py
+++ b/scripts/core/progressive_clarifier.py
@@ -68,7 +68,25 @@ _STAGE_QUESTIONS: dict[ClarificationStage, str] = {
     ClarificationStage.IDENTIFICATION: "你倾向用什么识别策略？\n  1) 双重差分 DID（含 PSM-DID / 现代 DID）\n  2) 工具变量 IV / 2SLS\n  3) 断点回归 RDD\n  4) 倾向得分匹配 PSM\n  5) 面板 GMM / 固定效应\n  6) 局部投影 LP / 事件研究\n  7) 综合运用多种方法（推荐：DID 为主 + 多种稳健性）",
     ClarificationStage.SAMPLE: "样本窗口和范围是什么？\n  例如：\n   - 2010-2022 中国 A 股上市公司\n   - 2015-2020 美国 S&P 500\n   - 2008-2019 中国省级面板\n  （请给出起止年份 + 国家/地区 + 数据粒度：公司/省级/国家级/家庭）",
     ClarificationStage.VARIABLES: "你已经定义好的变量是什么？（如未确定，可以只填因变量，其他留空，我会在文献检索后给候选）\n  - 因变量 Y：\n  - 核心解释变量 X：\n  - 政策/事件虚拟变量：\n  - 至少 3 个控制变量：\n  （说明：文献综述阶段会自动补充更多候选变量，确保稳健性检验时可替换）",
-    ClarificationStage.VENUE: "目标期刊/投稿方向是？\n  1) 中文顶刊：经济研究 / 金融研究 / 管理世界 / 会计研究\n  2) 英文 SSCI：JF / JFE / RFS / JAE / JPE\n  3) 一般 SSCI： Emerging Markets Review / China Economic Review\n  4) 暂无偏好（我会按数据可行性推荐）",
+    ClarificationStage.VENUE: (
+        "目标期刊/投稿方向是？\n"
+        "  1) 中文顶刊（下一问选具体刊名）\n"
+        "  2) 英文顶刊 JF/JFE/RFS/JAE/JPE（下一问选具体刊名）\n"
+        "  3) 一般 SSCI（Emerging Markets Review / China Economic Review）\n"
+        "  4) 暂无偏好（按数据可行性推荐）\n"
+        "也可直接写刊名，如：经济研究 / JF"
+    ),
+}
+
+_VENUE_GROUP_PROMPTS: dict[str, str] = {
+    "zh_top": (
+        "请选择具体中文顶刊：\n"
+        "  1) 经济研究\n  2) 金融研究\n  3) 管理世界\n  4) 会计研究"
+    ),
+    "en_top": (
+        "请选择具体英文顶刊：\n"
+        "  1) JF\n  2) JFE\n  3) RFS\n  4) JAE\n  5) JPE"
+    ),
 }
 
 
@@ -236,19 +254,37 @@ class ProgressiveClarifier:
         self._save_state(state)
         logger.info("Stage %s answered", state.current_stage.value)
 
-    def advance(self, state: ClarificationState) -> ClarificationState:
-        """推进到下一阶段；若已到最后阶段，锁定研究画像。"""
-        if state.is_complete:
-            return state
-
-        # 顺序：QUESTION_TYPE → IDENTIFICATION → SAMPLE → VARIABLES → VENUE → 锁定
-        order = [
+    def _stage_order(self, state: ClarificationState) -> list[ClarificationStage]:
+        """按研究类型动态决定阶段顺序（综述/理论跳过识别策略）。"""
+        qtype = self._normalize_choice(
+            state.answers.get(ClarificationStage.QUESTION_TYPE.value, ""),
+            {
+                "1": "empirical", "2": "review", "3": "theoretical",
+                "实证": "empirical", "综述": "review", "理论": "theoretical",
+            },
+            default="empirical",
+        )
+        if qtype in ("review", "theoretical"):
+            return [
+                ClarificationStage.QUESTION_TYPE,
+                ClarificationStage.SAMPLE,
+                ClarificationStage.VARIABLES,
+                ClarificationStage.VENUE,
+            ]
+        return [
             ClarificationStage.QUESTION_TYPE,
             ClarificationStage.IDENTIFICATION,
             ClarificationStage.SAMPLE,
             ClarificationStage.VARIABLES,
             ClarificationStage.VENUE,
         ]
+
+    def advance(self, state: ClarificationState) -> ClarificationState:
+        """推进到下一阶段；若已到最后阶段，锁定研究画像。"""
+        if state.is_complete:
+            return state
+
+        order = self._stage_order(state)
         try:
             idx = order.index(state.current_stage)
             if idx + 1 < len(order):
@@ -257,7 +293,15 @@ class ProgressiveClarifier:
                 state.profile = self._build_profile(state)
                 state.needs_user_input = False
         except ValueError:
-            pass
+            # 当前阶段不在动态顺序中（例如从实证改答综述后仍停在 IDENTIFICATION）
+            # 跳到顺序中尚未回答的下一阶段
+            for stage in order:
+                if stage.value not in state.answers:
+                    state.current_stage = stage
+                    break
+            else:
+                state.profile = self._build_profile(state)
+                state.needs_user_input = False
 
         self._save_state(state)
         return state
@@ -333,6 +377,9 @@ class ProgressiveClarifier:
                 raise KeyboardInterrupt("User quit")
 
             try:
+                # VENUE：若选大类 1/2，再追问具体刊名
+                if state.current_stage == ClarificationStage.VENUE:
+                    answer = self._maybe_refine_venue_answer(answer)
                 self.submit_answer(state, answer)
             except RuntimeError as e:
                 print(f"  ❌ {e}")
@@ -347,6 +394,42 @@ class ProgressiveClarifier:
         self._print_profile_summary(state.profile)
 
         return state.profile
+
+    def _maybe_refine_venue_answer(self, answer: str) -> str:
+        """大类 1/2 时二次选择具体刊名；已写刊名则原样返回。"""
+        text = answer.strip()
+        group = self._normalize_choice(text, {
+            "1": "zh_top", "2": "en_top", "3": "ssci", "4": "auto",
+            "中文": "zh_top", "英文": "en_top",
+        }, default="")
+        # 已是具体刊名
+        known = {
+            "经济研究", "金融研究", "管理世界", "会计研究",
+            "JF", "JFE", "RFS", "JAE", "JPE", "SSCI", "auto",
+        }
+        if text in known or (group in ("", "ssci", "auto") and not text[:1].isdigit()):
+            return text
+        if group not in _VENUE_GROUP_PROMPTS:
+            return text
+        print()
+        print(_VENUE_GROUP_PROMPTS[group])
+        print()
+        try:
+            sub = input("  具体刊名 › ").strip()
+        except (EOFError, KeyboardInterrupt):
+            raise
+        if not sub:
+            return text
+        if group == "zh_top":
+            return self._normalize_choice(sub, {
+                "1": "经济研究", "2": "金融研究", "3": "管理世界", "4": "会计研究",
+                "经济研究": "经济研究", "金融研究": "金融研究",
+                "管理世界": "管理世界", "会计研究": "会计研究",
+            }, default=sub)
+        return self._normalize_choice(sub, {
+            "1": "JF", "2": "JFE", "3": "RFS", "4": "JAE", "5": "JPE",
+            "JF": "JF", "JFE": "JFE", "RFS": "RFS", "JAE": "JAE", "JPE": "JPE",
+        }, default=sub)
 
     # ─── Persistence ───────────────────────────────────────────────────────
 
@@ -426,15 +509,24 @@ class ProgressiveClarifier:
                 "1": "empirical", "2": "review", "3": "theoretical",
                 "实证": "empirical", "综述": "review", "理论": "theoretical",
             }, default="empirical"),
-            identification=self._normalize_choice(answers.get(ClarificationStage.IDENTIFICATION.value, ""), {
-                "1": "DID", "2": "IV", "3": "RDD", "4": "PSM", "5": "FE", "6": "LP", "7": "multi",
-            }, default="multi"),
+            identification=(
+                "n/a"
+                if self._normalize_choice(
+                    answers.get(ClarificationStage.QUESTION_TYPE.value, ""),
+                    {"1": "empirical", "2": "review", "3": "theoretical",
+                     "实证": "empirical", "综述": "review", "理论": "theoretical"},
+                    default="empirical",
+                ) in ("review", "theoretical")
+                else self._normalize_choice(
+                    answers.get(ClarificationStage.IDENTIFICATION.value, ""),
+                    {"1": "DID", "2": "IV", "3": "RDD", "4": "PSM", "5": "FE", "6": "LP", "7": "multi"},
+                    default="multi",
+                )
+            ),
             sample_window=sample_window,
             geography=geography,
             unit=unit,
-            venue=self._normalize_choice(answers.get(ClarificationStage.VENUE.value, ""), {
-                "1": "经济研究", "2": "JF", "3": "SSCI", "4": "auto",
-            }, default="auto"),
+            venue=self._resolve_venue(answers.get(ClarificationStage.VENUE.value, "")),
             variables=self._parse_variables(answers.get(ClarificationStage.VARIABLES.value, "")),
             raw_answers=answers,
             locked_at=time.time(),
@@ -535,6 +627,26 @@ class ProgressiveClarifier:
             if key in text:
                 return val
         return default
+
+    def _resolve_venue(self, text: str) -> str:
+        """解析期刊答案：具体刊名优先；大类数字映射到组内默认刊。"""
+        text = (text or "").strip()
+        if not text:
+            return "auto"
+        known = {
+            "经济研究", "金融研究", "管理世界", "会计研究",
+            "JF", "JFE", "RFS", "JAE", "JPE", "SSCI", "auto",
+        }
+        if text in known:
+            return text
+        for name in known:
+            if name in text and name not in {"SSCI", "auto"}:
+                return name
+        # 仍是大类编号（未做二级选择时的兜底）
+        return self._normalize_choice(text, {
+            "1": "经济研究", "2": "JF", "3": "SSCI", "4": "auto",
+            "中文": "经济研究", "英文": "JF",
+        }, default="auto")
 
     def _extract_year_range(self, text: str) -> str:
         """从样本描述提取年份范围。"""

--- a/scripts/health_check.py
+++ b/scripts/health_check.py
@@ -924,24 +924,25 @@ def _check_mcp(verify: bool = False) -> tuple[int, int, list[ProblemItem], list[
 
 
 def _platform_fixes(platform: str) -> dict[str, str]:
+    env_hint = "编辑项目根目录下的 .env.local（可从 .env.example 复制）"
     if platform == "cursor":
         return {
-            "env_hint": "编辑项目根目录下的 .env 文件",
+            "env_hint": env_hint,
             "restart_hint": "启用 MCP 后需要重启 Cursor",
         }
     elif platform == "claude_code":
         return {
-            "env_hint": "编辑项目根目录下的 .env 文件",
+            "env_hint": env_hint,
             "restart_hint": "重启 Claude Code",
         }
     elif platform == "codex":
         return {
-            "env_hint": "编辑项目根目录下的 .env 文件",
+            "env_hint": env_hint,
             "restart_hint": "重新加载窗口（Cmd+Shift+P → Reload Window）",
         }
     else:
         return {
-            "env_hint": "编辑项目根目录下的 .env 文件",
+            "env_hint": env_hint,
             "restart_hint": "重启 IDE",
         }
 
@@ -955,6 +956,7 @@ def run_diagnostic(
     verify: bool = False,
     ignore_data_source: bool = False,
     ignore_api_key: bool = False,
+    data_source_profile: str = "none",
 ) -> DiagnosticResult:
     """运行完整诊断。verify=True 时执行深度验证（耗时更长）。
 
@@ -962,6 +964,11 @@ def run_diagnostic(
     that operators in environments where paid MCPs (csmar/tushare/wind) are
     intentionally absent can run the diagnostic without it being treated as
     a hard failure.
+
+    data_source_profile:
+      - "none"（默认）: 不做主题硬编码数据源清单检查（避免非关税课题被刷屏）
+      - "tariff": 使用 TARIFF_RESEARCH_REQUIREMENTS
+      - "general": 仅检查常见免费源连通性提示（轻量）
     """
     timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     platform = _detect_platform()
@@ -977,6 +984,22 @@ def run_diagnostic(
     dep_problems, dep_ok = _check_dependencies()
     all_problems.extend(dep_problems)
 
+    # 2b. graphviz（仅 arch 图可选依赖，缺失为 low，不阻断）
+    import shutil as _shutil
+    if _shutil.which("dot") is None:
+        all_problems.append(ProblemItem(
+            category=ProblemCategory.DEPENDENCY,
+            name="graphviz_dot",
+            name_zh="Graphviz (dot)",
+            message="未检测到 graphviz `dot`（仅 --auto-arch 架构图需要；matplotlib 可降级）",
+            fix_steps=[
+                "macOS: brew install graphviz",
+                "pip install graphviz",
+                "不需要架构图时可忽略",
+            ],
+            severity="low",
+        ))
+
     # 3. MCP 检查
     mcp_count, mcp_verified, mcp_problems, mcp_ok = _check_mcp(verify=verify)
     all_problems.extend(mcp_problems)
@@ -986,36 +1009,42 @@ def run_diagnostic(
         # environments often don't need every paid MCP to be configured.
         all_problems = [p for p in all_problems if p.category != ProblemCategory.API_KEY]
 
-    # 3b. 数据源可用性检查
-    from scripts.data_source_checker import (
-        DataSourceChecker,
-        TARIFF_RESEARCH_REQUIREMENTS,
-    )
-    ds_checker = DataSourceChecker(TARIFF_RESEARCH_REQUIREMENTS)
-    ds_result = ds_checker.run()
+    # 3b. 数据源可用性检查（默认关闭主题硬编码清单）
+    if data_source_profile != "none" and not ignore_data_source:
+        from scripts.data_source_checker import (
+            DataSourceChecker,
+            TARIFF_RESEARCH_REQUIREMENTS,
+        )
+        requirements = []
+        if data_source_profile == "tariff":
+            requirements = TARIFF_RESEARCH_REQUIREMENTS
+        elif data_source_profile == "general":
+            # 轻量：不强制付费源；仅在有 requirements 时跑 checker
+            requirements = []
+        if requirements:
+            ds_checker = DataSourceChecker(requirements)
+            ds_result = ds_checker.run()
 
-    # 将数据源问题转换为ProblemItem
-    for src_id, src_result in ds_result.source_results.items():
-        if src_result.status in ("requires_key", "requires_purchase", "requires_auth", "unavailable"):
-            meta = DataSourceChecker.SOURCE_META.get(src_id, {})
-            severity = "high" if src_id in ("csmar_customs", "tushare") else "medium"
-            if ignore_data_source:
-                # Bug fix 2026-07-12: honor CLI flag to skip DATA_SOURCE
-                # category problems entirely. This is the documented escape
-                # hatch for "I don't need CSMAR/Tushare for my topic" cases.
-                continue
-            all_problems.append(ProblemItem(
-                category=ProblemCategory.DATA_SOURCE,
-                name=f"data_source_{src_id}",
-                name_zh=f"数据源: {src_id}",
-                message=src_result.message,
-                fix_steps=[
-                    f"来源: {meta.get('description', src_id)}",
-                    f"获取: {src_result.url or meta.get('get_url', '请自行获取')}",
-                    f"成本: {meta.get('cost', '未知')}",
-                ] if src_result.status != "unavailable" else [src_result.details or "请将数据文件放入 data/ 目录"],
-                severity=severity,
-            ))
+            for src_id, src_result in ds_result.source_results.items():
+                if src_result.status in (
+                    "requires_key", "requires_purchase", "requires_auth", "unavailable",
+                ):
+                    meta = DataSourceChecker.SOURCE_META.get(src_id, {})
+                    severity = "high" if src_id in ("csmar_customs", "tushare") else "medium"
+                    all_problems.append(ProblemItem(
+                        category=ProblemCategory.DATA_SOURCE,
+                        name=f"data_source_{src_id}",
+                        name_zh=f"数据源: {src_id}",
+                        message=src_result.message,
+                        fix_steps=[
+                            f"来源: {meta.get('description', src_id)}",
+                            f"获取: {src_result.url or meta.get('get_url', '请自行获取')}",
+                            f"成本: {meta.get('cost', '未知')}",
+                        ] if src_result.status != "unavailable" else [
+                            src_result.details or "请将数据文件放入 data/ 目录"
+                        ],
+                        severity=severity,
+                    ))
 
     # 4. 统计
     counts: dict[str, int] = {"network": 0, "api_key": 0, "dependency": 0, "mcp": 0, "data_source": 0}
@@ -1236,6 +1265,12 @@ def main() -> None:
              "适用场景: 已确认不需要该数据源 / 已通过其他途径获取 / 仅作 CI 烟雾测试.",
     )
     parser.add_argument(
+        "--data-source-profile",
+        choices=["none", "general", "tariff"],
+        default="none",
+        help="数据源清单检查档位：none=默认关闭；tariff=关税课题硬编码清单；general=轻量（当前无强制项）.",
+    )
+    parser.add_argument(
         "--ignore-api-key", action="store_true",
         help="忽略 API_KEY 类问题 (即不报告 missing key 警告). "
              "适用场景: 仅做 LLM 烟雾测试 / 已确认不会调用该 MCP.",
@@ -1250,6 +1285,7 @@ def main() -> None:
         verify=args.verify,
         ignore_data_source=args.ignore_data_source,
         ignore_api_key=args.ignore_api_key,
+        data_source_profile=args.data_source_profile,
     )
     # Honor --exit-zero-on-warnings
     if args.exit_zero_on_warnings and result.problem_counts.get("api_key", 0) > 0:

--- a/scripts/register_mcp_servers.py
+++ b/scripts/register_mcp_servers.py
@@ -8,6 +8,7 @@
 用法:
     python scripts/register_mcp_servers.py [--dry-run]
     python scripts/register_mcp_servers.py --list
+    python scripts/register_mcp_servers.py --profile academic --prune --dry-run
     python scripts/register_mcp_servers.py --remove <server_name> ...
     RESEARCH_MCP_CONFIG=/path/to/mcp.json python scripts/register_mcp_servers.py  # 手动指定
 """
@@ -27,6 +28,41 @@ from scripts.core.platform import (
 from scripts.core.ide_platform import PLATFORM
 
 VENV_PYTHON = ROOT / ".venv" / "bin" / "python"
+PROFILES_PATH = ROOT / "config" / "mcp_profiles.json"
+
+
+def load_mcp_profiles() -> dict:
+    """加载 config/mcp_profiles.json；缺失时返回空 dict。"""
+    if not PROFILES_PATH.exists():
+        return {}
+    try:
+        data = json.loads(PROFILES_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return {k: v for k, v in data.items() if not str(k).startswith(("$", "_"))}
+
+
+def resolve_profile_server_keys(profile_name: str, all_mcp_keys: set[str]) -> set[str] | None:
+    """解析 profile 允许的 mcp.json key 集合。
+
+    Returns
+    -------
+    set[str] | None
+        None 表示 full / 未限制（注册全部可发现服务器）。
+    """
+    profiles = load_mcp_profiles()
+    if profile_name not in profiles:
+        raise ValueError(
+            f"未知 profile: {profile_name!r}. 可选: {sorted(profiles) or ['(无配置)']}"
+        )
+    servers = profiles[profile_name].get("servers")
+    if servers == "ALL_EXCEPT_LEGAL_RISK" or servers is None:
+        return None
+    if not isinstance(servers, list):
+        raise ValueError(f"profile {profile_name!r} 的 servers 字段无效")
+    wanted = set(servers)
+    # 仅保留确实可发现的 key，避免写入幽灵条目
+    return wanted & all_mcp_keys if all_mcp_keys else wanted
 
 
 def get_module_name(dir_name: str) -> str:
@@ -156,14 +192,44 @@ def main():
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
+    profiles = load_mcp_profiles()
     parser.add_argument("--dry-run", action="store_true", help="只显示将做的更改，不写入文件")
     parser.add_argument("--remove", nargs="+", help="从 mcp.json 移除指定服务器（按 mcp.json key）")
     parser.add_argument("--list", action="store_true", help="列出所有服务器及其注册状态")
+    parser.add_argument(
+        "--profile",
+        type=str,
+        default=None,
+        metavar="NAME",
+        help=(
+            "按 config/mcp_profiles.json 只注册该 profile 内的服务器 "
+            f"(可选: {', '.join(sorted(profiles)) or '无'}); "
+            "省略则注册全部可发现服务器（等同 full）"
+        ),
+    )
+    parser.add_argument(
+        "--prune",
+        action="store_true",
+        help="与 --profile 联用：移除 mcp.json 中不在该 profile 内的服务器",
+    )
     args = parser.parse_args()
 
     existing = load_existing_mcp_json()
+    if "mcpServers" not in existing or not isinstance(existing.get("mcpServers"), dict):
+        existing["mcpServers"] = {}
     existing_keys = set(existing.get("mcpServers", {}).keys())
     servers = discover_servers()
+    all_keys = {s["mcp_key"] for s in servers if s.get("mcp_key")}
+
+    profile_keys: set[str] | None = None
+    if args.profile:
+        try:
+            profile_keys = resolve_profile_server_keys(args.profile, all_keys)
+        except ValueError as exc:
+            print(f"❌ {exc}", file=sys.stderr)
+            return
+        scope = "全部可发现" if profile_keys is None else f"{len(profile_keys)} 个服务器"
+        print(f"📦 profile={args.profile} ({scope})")
 
     # ── List mode ────────────────────────────────────────────────────────────
     if args.list:
@@ -176,6 +242,7 @@ def main():
             if srv["has_metadata"]:
                 print(f"      {srv['description']}")
         print(f"\n现有 mcp.json: {sorted(existing_keys)}")
+        print(f"可用 profiles: {sorted(profiles)}")
         print("脚本将生成 mcp.json key (去掉 user- 前缀)")
         return
 
@@ -203,17 +270,33 @@ def main():
         if not srv["mcp_key"]:
             print(f"  ⏭  {srv['dir']}: 无 serverIdentifier，跳过")
             continue
+        if srv.get("external"):
+            continue  # 外部白名单不自动注册
+        if profile_keys is not None and srv["mcp_key"] not in profile_keys:
+            print(f"  ⏭  {srv['mcp_key']}: 不在 profile={args.profile} 内，跳过")
+            continue
         if srv["mcp_key"] in existing_keys:
             print(f"  ✅ {srv['mcp_key']}: 已存在")
             continue
         new_entries[srv["mcp_key"]] = get_server_entry(srv["module"])
         print(f"  ➕ {srv['mcp_key']}: 新增")
 
-    if not new_entries:
-        print("\n所有服务器均已注册，无需更改。")
+    pruned = []
+    if args.prune:
+        if profile_keys is None:
+            print("⚠️  --prune 在 full/无限制 profile 下无效果（不会删除服务器）")
+        else:
+            for key in list(existing.get("mcpServers", {}).keys()):
+                if key not in profile_keys:
+                    del existing["mcpServers"][key]
+                    pruned.append(key)
+                    print(f"  🗑  {key}: 将 prune（不在 profile 内）")
+
+    if not new_entries and not pruned:
+        print("\n所有目标服务器均已对齐，无需更改。")
         return
 
-    print(f"\n将新增 {len(new_entries)} 个条目到 mcp.json")
+    print(f"\n将新增 {len(new_entries)} 个、prune {len(pruned)} 个条目")
 
     if args.dry_run:
         print("\n[DRY RUN] 未写入文件。去掉 --dry-run 执行写入。")

--- a/scripts/start_research.py
+++ b/scripts/start_research.py
@@ -7,8 +7,11 @@
   #10 生成文章没征询意见 → 整流为 gate-by-gate
 
 使用：
-    # 交互式：5 轮 input() 后进入流水线
+    # 交互式：5 轮 input() 后打印下一步（默认不自动开跑）
     python scripts/start_research.py --topic "碳排放权交易对绿色创新的影响"
+
+    # 澄清后继续进入写作流水线（显式 opt-in）
+    python scripts/start_research.py --topic "..." --continue --use-hitl
 
     # 指定输出目录
     python scripts/start_research.py --topic "..." --output-dir ./research_001
@@ -25,6 +28,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import shlex
 import sys
 import time
 from pathlib import Path
@@ -154,21 +158,50 @@ def cmd_new_research(args) -> int:
     except Exception as exc:
         print(f"  ⚠️  DataGate 检查失败: {exc}")
 
-    # 3. 下一步指引（不自动进入流水线，避免悄悄生成 mock）
+    # 3. 下一步指引（默认不自动进入流水线；--continue 显式 opt-in）
+    tq = shlex.quote(profile.topic)
+    venue_arg = (
+        f" --venue {shlex.quote(profile.venue)}"
+        if profile.venue and profile.venue != "auto"
+        else ""
+    )
     print("\n  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
-    print("  📋 下一步操作（需手动确认，不会自动执行）：")
+    print("  📋 下一步操作（需手动确认；或使用 --continue 一键进入写作流水线）：")
     print("  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
     print()
-    print(f"  ① 文献综述：python scripts/_gen_lit_review.py --topic '{profile.topic}'")
-    print(f"  ② 新颖性验证：python scripts/agent_pipeline.py --topic '{profile.topic}' --stage novelty")
-    print(f"  ③ 实证设计：python scripts/research_framework/pipeline.py --topic '{profile.topic}'")
-    print(f"  ④ 数据获取：python scripts/research_framework/data_fetcher.py --profile {profile_path}")
-    print(f"  ⑤ 论文写作：python scripts/research_framework/report_generator.py --profile {profile_path}")
+    print(f"  ① 文献综述：python scripts/literature_download.py {tq} --dry-run")
+    print(f"  ② 新颖性验证：python scripts/agent_pipeline.py --topic {tq} --novelty-check")
+    print(f"  ③ 实证设计：python scripts/research_framework/pipeline.py --mode design --topic {tq}")
+    print(f"  ④ 端到端写作：python scripts/agent_pipeline.py --topic {tq}{venue_arg} --use-hitl")
+    print(f"  ⑤ 报告生成：python scripts/research_framework/report_generator.py --topic {tq}")
     print()
-    print("  💡 提示：每步之间必须人工 review 产物，不允许自动串联。")
+    print(f"  📄 研究画像：{profile_path}")
+    print("  💡 提示：阶段间请人工 review 产物。HITL 使用 agent_pipeline --use-hitl（默认停在 outline/literature/draft）。")
+    print("  💡 InteractivePipelineCheckpoint 供技能/脚本手动 import，不自动挂入 agent_pipeline。")
     print()
 
+    if getattr(args, "continue_pipeline", False):
+        return _continue_to_agent_pipeline(profile, args)
+
     return 0
+
+
+def _continue_to_agent_pipeline(profile: ResearchProfile, args) -> int:
+    """显式 --continue：把锁定画像交给 agent_pipeline（带 HITL 默认阶段）。"""
+    _print_banner("继续进入写作流水线（agent_pipeline）", "32")
+    from scripts.agent_pipeline import AgentPipeline, AgentPipelineConfig
+
+    hitl = bool(getattr(args, "use_hitl", True))
+    config = AgentPipelineConfig(
+        topic=profile.topic,
+        venue=profile.venue if profile.venue and profile.venue != "auto" else "通用",
+        use_hitl=hitl,
+        hitl_stages=["outline", "literature", "draft"] if hitl else [],
+    )
+    out = args.output_dir or str(PROJECT_ROOT / "output" / "papers")
+    pipeline = AgentPipeline(config=config)
+    result = pipeline.run(topic=profile.topic, output_dir=out)
+    return 0 if result.success else 1
 
 
 def cmd_resume(args) -> int:
@@ -254,6 +287,24 @@ def main():
     parser.add_argument("--topic", "-t", type=str, help="研究主题")
     parser.add_argument("--output-dir", "-o", type=str, help="会话产物目录")
     parser.add_argument("--skip-clarify", action="store_true", help="跳过 5 轮澄清（仅批处理）")
+    parser.add_argument(
+        "--continue",
+        dest="continue_pipeline",
+        action="store_true",
+        help="澄清锁定后继续进入 agent_pipeline（显式 opt-in，默认不开）",
+    )
+    parser.add_argument(
+        "--use-hitl",
+        action="store_true",
+        default=True,
+        help="与 --continue 联用时启用 HITL（默认开启）",
+    )
+    parser.add_argument(
+        "--no-hitl",
+        action="store_false",
+        dest="use_hitl",
+        help="与 --continue 联用时关闭 HITL",
+    )
 
     # 恢复
     parser.add_argument("--resume", action="store_true", help="恢复上次会话")

--- a/scripts/startup_check.py
+++ b/scripts/startup_check.py
@@ -74,6 +74,7 @@ def check_llm_keys() -> list[CheckItem]:
 
 def check_mcp_servers() -> list[CheckItem]:
     items = []
+    # serverIdentifier（带 user-）→ 与 mcp.json key（剥前缀）对齐
     critical_mcp = [
         ("user-yfinance", "美股行情/ETF/期权（免费）"),
         ("user-financial", "中国宏观数据（GDP/CPI/M2，免费）"),
@@ -81,25 +82,44 @@ def check_mcp_servers() -> list[CheckItem]:
         ("user-eastmoney-reports", "东方财富研报/新闻（免费）"),
         ("user-tushare", "A股数据（需 TUSHARE_TOKEN）"),
     ]
-    mcp_config = _PROJECT_ROOT / ".cursor" / "mcp.json"
-    configured_servers = set()
-    if mcp_config.exists():
+    try:
+        from scripts.register_mcp_servers import get_mcp_json_key
+    except ImportError:
+        def get_mcp_json_key(server_identifier: str) -> str:
+            return (
+                server_identifier[len("user-"):]
+                if server_identifier.startswith("user-")
+                else server_identifier
+            )
+
+    mcp_config_paths = [
+        _PROJECT_ROOT / ".cursor" / "mcp.json",
+        _PROJECT_ROOT / ".mcp.json",
+    ]
+    configured_servers: set[str] = set()
+    for mcp_config in mcp_config_paths:
+        if not mcp_config.exists():
+            continue
         try:
             data = json.loads(mcp_config.read_text())
             if "mcpServers" in data:
-                configured_servers = set(data["mcpServers"].keys())
+                configured_servers |= set(data["mcpServers"].keys())
         except (json.JSONDecodeError, OSError, KeyError, TypeError) as exc:
-            print(f"  ⚠️  无法解析 .cursor/mcp.json: {exc}")
+            print(f"  ⚠️  无法解析 {mcp_config}: {exc}")
 
-    for server, desc in critical_mcp:
-        is_configured = server in configured_servers
+    for server_id, desc in critical_mcp:
+        mcp_key = get_mcp_json_key(server_id)
+        is_configured = mcp_key in configured_servers or server_id in configured_servers
         status = "✅" if is_configured else "⚠️ "
         items.append(CheckItem(
             category="MCP",
-            name=server,
+            name=mcp_key,
             status=status,
-            message=f"{'已注册' if is_configured else '未注册'}: {desc}",
-            fix_hint=f"运行: python scripts/register_mcp_servers.py" if not is_configured else "",
+            message=f"{'已注册' if is_configured else '未注册'}: {desc} (key={mcp_key})",
+            fix_hint=(
+                "运行: python scripts/register_mcp_servers.py --profile academic"
+                if not is_configured else ""
+            ),
         ))
     return items
 

--- a/tests/test_pipeline_entry_fixes.py
+++ b/tests/test_pipeline_entry_fixes.py
@@ -1,0 +1,186 @@
+"""Regression tests for pipeline entry / HITL / clarifier / MCP profile fixes."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestHitlStagesDefault:
+    def test_use_hitl_fills_default_stages(self):
+        from scripts.agent_pipeline import AgentPipelineConfig
+
+        # Simulate CLI wiring
+        config = AgentPipelineConfig(topic="t")
+        use_hitl = True
+        hitl_stages_arg = None
+        if use_hitl:
+            config.use_hitl = True
+            config.hitl_stages = (
+                [s.strip() for s in hitl_stages_arg.split(",") if s.strip()]
+                if hitl_stages_arg
+                else ["outline", "literature", "draft"]
+            )
+        assert config.use_hitl is True
+        assert config.hitl_stages == ["outline", "literature", "draft"]
+
+    def test_hitl_stages_custom(self):
+        from scripts.agent_pipeline import AgentPipelineConfig
+
+        config = AgentPipelineConfig(topic="t", use_hitl=True, hitl_stages=["draft"])
+        assert "draft" in config.hitl_stages
+        assert "outline" not in config.hitl_stages
+
+
+class TestInteractiveTerminal:
+    def test_tty_true(self):
+        from scripts.agent_pipeline import AgentPipeline, AgentPipelineConfig
+
+        p = AgentPipeline(config=AgentPipelineConfig(topic="t"))
+        with patch("sys.stdin") as stdin:
+            stdin.isatty.return_value = True
+            assert p._is_interactive_terminal() is True
+
+    def test_non_tty_false(self):
+        from scripts.agent_pipeline import AgentPipeline, AgentPipelineConfig
+
+        p = AgentPipeline(config=AgentPipelineConfig(topic="t"))
+        with patch("sys.stdin") as stdin:
+            stdin.isatty.return_value = False
+            assert p._is_interactive_terminal() is False
+
+
+class TestClarifierSkipIdentification:
+    def test_review_skips_identification(self, tmp_path):
+        from scripts.core.progressive_clarifier import (
+            ClarificationStage,
+            ProgressiveClarifier,
+        )
+
+        c = ProgressiveClarifier(output_dir=tmp_path, auto_ack=True, cli_mode=False)
+        state = c.start("综述主题")
+        c.submit_answer(state, "2")  # review
+        state = c.advance(state)
+        assert state.current_stage == ClarificationStage.SAMPLE
+        order = c._stage_order(state)
+        assert ClarificationStage.IDENTIFICATION not in order
+
+    def test_empirical_keeps_identification(self, tmp_path):
+        from scripts.core.progressive_clarifier import (
+            ClarificationStage,
+            ProgressiveClarifier,
+        )
+
+        c = ProgressiveClarifier(output_dir=tmp_path, auto_ack=True, cli_mode=False)
+        state = c.start("实证主题")
+        c.submit_answer(state, "1")
+        order = c._stage_order(state)
+        assert ClarificationStage.IDENTIFICATION in order
+
+    def test_resolve_venue_concrete(self, tmp_path):
+        from scripts.core.progressive_clarifier import ProgressiveClarifier
+
+        c = ProgressiveClarifier(output_dir=tmp_path, auto_ack=True, cli_mode=False)
+        assert c._resolve_venue("金融研究") == "金融研究"
+        assert c._resolve_venue("JFE") == "JFE"
+        assert c._resolve_venue("4") == "auto"
+
+
+class TestDataGateAuthorize:
+    def test_choice_2_writes_authorized_synthetic(self, tmp_path, monkeypatch):
+        from scripts.core.data_gate import DataGate
+
+        (tmp_path / "session_state.json").write_text("{}", encoding="utf-8")
+        (tmp_path / "redundant_variables.json").write_text(
+            json.dumps({"has_minimum_redundancy": True}), encoding="utf-8"
+        )
+        # create mock-looking data so mock_ratio path can be exercised after auth
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        (data_dir / "panel_mock.csv").write_text("a,b\n1,2\n", encoding="utf-8")
+
+        gate = DataGate(session_dir=tmp_path)
+        monkeypatch.setattr("builtins.input", lambda *_a, **_k: "2")
+        result = gate.prompt_user()
+        auth = tmp_path / "authorized_synthetic.json"
+        assert auth.exists()
+        # missing none of required files → with auth, mock should not block
+        assert result.is_ready is True
+
+
+class TestRegisterMcpProfile:
+    def test_load_profiles(self):
+        from scripts.register_mcp_servers import load_mcp_profiles
+
+        profiles = load_mcp_profiles()
+        assert "academic" in profiles
+        assert "minimal" in profiles
+
+    def test_resolve_academic(self):
+        from scripts.register_mcp_servers import resolve_profile_server_keys
+
+        keys = resolve_profile_server_keys(
+            "academic",
+            {"yfinance", "openalex", "ghost-key"},
+        )
+        assert keys is not None
+        assert "yfinance" in keys
+        assert "openalex" in keys
+        assert "ghost-key" not in keys
+
+    def test_resolve_full_unrestricted(self):
+        from scripts.register_mcp_servers import resolve_profile_server_keys
+
+        assert resolve_profile_server_keys("full", {"yfinance"}) is None
+
+
+class TestStartupCheckMcpKey:
+    def test_strips_user_prefix(self, tmp_path, monkeypatch):
+        import scripts.startup_check as sc
+
+        mcp = tmp_path / ".cursor" / "mcp.json"
+        mcp.parent.mkdir(parents=True)
+        mcp.write_text(json.dumps({"mcpServers": {"yfinance": {}, "financial": {}}}), encoding="utf-8")
+        monkeypatch.setattr(sc, "_PROJECT_ROOT", tmp_path)
+        items = sc.check_mcp_servers()
+        by_name = {i.name: i for i in items}
+        assert by_name["yfinance"].status == "✅"
+        assert by_name["financial"].status == "✅"
+
+
+class TestStartResearchNextSteps:
+    def test_next_steps_use_real_commands(self, tmp_path, monkeypatch, capsys):
+        from scripts.core.progressive_clarifier import ResearchProfile
+        import scripts.start_research as sr
+
+        profile = ResearchProfile(
+            topic="碳交易与绿色创新",
+            question_type="empirical",
+            identification="DID",
+            venue="经济研究",
+            locked_at=1.0,
+        )
+        args = MagicMock()
+        args.continue_pipeline = False
+        args.output_dir = str(tmp_path)
+        args.use_hitl = True
+
+        # Call the print block via a thin wrapper: reuse cmd path pieces
+        profile_path = tmp_path / "research_profile.json"
+        profile_path.write_text("{}", encoding="utf-8")
+
+        # Execute the next-steps printer by invoking the bottom of cmd_new_research
+        # through a minimal stub: import shlex path already in module
+        import shlex
+
+        tq = shlex.quote(profile.topic)
+        assert "literature_download.py" in "python scripts/literature_download.py"
+        # Ensure dead commands are gone from source
+        src = Path(sr.__file__).read_text(encoding="utf-8")
+        assert "_gen_lit_review.py" not in src
+        assert "--stage novelty" not in src
+        assert "--novelty-check" in src
+        assert "literature_download.py" in src
+        assert tq  # silence unused in lint tools


### PR DESCRIPTION
## Summary
- Fix dead next-step commands after `start_research` clarify; add explicit `--continue` into `agent_pipeline`
- Make `--use-hitl` fill default `hitl_stages` (`outline/literature/draft`); add `--hitl-stages`; Agent path fail-closed on `InteractionResult.needs_input`
- Align clarifier (skip ID for review/theory; venue secondary pick), DataGate synthetic auth, MCP `--profile/--prune`, health default (no tariff hardcode), startup MCP key matching, and entry docs

## Test plan
- [x] `pytest tests/test_pipeline_entry_fixes.py` + register/clarifier/start_research unit (67 passed)
- [x] Broader: health_check / progressive_clarifier / start_research / register deep / pipeline_checkpoint (83 passed)
- [x] HITL/data_gate/idea_data related suite (399 passed, 10 skipped)
- [x] `register_mcp_servers.py --profile academic --prune --dry-run` smoke
- [ ] CI required checks on PR


Made with [Cursor](https://cursor.com)