### PR TITLE
fix: close remaining pipeline UX leftovers after #176

### DIFF
--- a/.agents/skills/fin-full-pipeline/SKILL.md
+++ b/.agents/skills/fin-full-pipeline/SKILL.md
@@ -301,7 +301,7 @@ config = AgentPipelineConfig(
     topic="[研究方向]",
     venue="[目标期刊]",
     research_field="[研究领域]",
-    use_hitl=False,
+    use_hitl=True,  # outline/literature/draft gates; set False only for batch CI
     visualize=True,
 )
 pipeline = AgentPipeline(config=config)
@@ -935,7 +935,7 @@ config = AgentPipelineConfig(
     topic="[研究方向]",
     venue="[目标期刊]",
     research_field="[研究领域]",
-    use_hitl=False,
+    use_hitl=True,  # outline/literature/draft gates; set False only for batch CI
     visualize=True,
 )
 pipeline = AgentPipeline(config=config)

--- a/.cursor/skills/fin-full-pipeline/SKILL.md
+++ b/.cursor/skills/fin-full-pipeline/SKILL.md
@@ -301,7 +301,7 @@ config = AgentPipelineConfig(
     topic="[研究方向]",
     venue="[目标期刊]",
     research_field="[研究领域]",
-    use_hitl=False,
+    use_hitl=True,  # outline/literature/draft gates; set False only for batch CI
     visualize=True,
 )
 pipeline = AgentPipeline(config=config)
@@ -935,7 +935,7 @@ config = AgentPipelineConfig(
     topic="[研究方向]",
     venue="[目标期刊]",
     research_field="[研究领域]",
-    use_hitl=False,
+    use_hitl=True,  # outline/literature/draft gates; set False only for batch CI
     visualize=True,
 )
 pipeline = AgentPipeline(config=config)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,9 +60,10 @@ Stage 7: Paper Draft         → scripts/research_framework/report_generator.py
 Stage 8: Review              → scripts/core/llm_reviewer.py
 ```
 
-Each stage requires user confirmation (HITL). Do NOT auto-continue past a stage.
-`--use-hitl` enables outline/literature/draft gates by default. `InteractivePipelineCheckpoint`
-is for skills/manual import only — not auto-wired into `agent_pipeline`.
+Each stage should pause for user confirmation when HITL is enabled.
+Use `python scripts/agent_pipeline.py --topic "..." --use-hitl` (defaults to
+outline/literature/draft gates). `run_research.py` also defaults to HITL;
+set `FINAI_NO_HITL=1` or `--no-use-hitl` for batch. Do NOT auto-continue past a stage.
 
 ---
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -533,19 +533,17 @@ PYTHONIOENCODING=utf-8
 
 ---
 
-### Q29: `scripts/run_research.py` 报 `FileNotFoundError`
+### Q29: `scripts/run_research.py` 与 HITL
 
-**原因**：`run_research.py` 可能是占位符脚本。
+**说明**：`run_research.py` 是可视化队列 Runner，默认开启阶段 HITL（outline/literature/draft）。非 TTY 批处理需 `--no-use-hitl` 或 `FINAI_NO_HITL=1`。
 
-**解决**：
+**推荐主入口**（写作流水线）：
 ```bash
-# 使用主入口
-python3 scripts/agent_pipeline.py --topic "碳排放权交易对企业绿色创新的影响"
+python scripts/agent_pipeline.py --topic "碳排放权交易对企业绿色创新的影响" --use-hitl
 
-# 或使用交互式向导
-python3 scripts/setup_wizard.py --interactive
+# 或先澄清再写作
+python scripts/start_research.py --topic "..." --continue --use-hitl
 ```
-
 ---
 
 ### Q30: 如何获取帮助？

--- a/scripts/agent_pipeline.py
+++ b/scripts/agent_pipeline.py
@@ -116,7 +116,7 @@ class InteractionResult:
     - limitations: 受限功能清单
     - options: 可供调用方展示给用户的结构化选项
     - recommended_option: 推荐选项的 id；Mock 永远不会被设为推荐
-    - can_proceed: 是否可以继续研究
+    - can_proceed: 派生属性，等价于 not needs_input and action_needed == \"proceed\"
     """
     needs_input: bool = False
     action_needed: str = "proceed"   # "proceed" | "ask_api_key" | "ask_llm_confirm"
@@ -127,6 +127,10 @@ class InteractionResult:
     llm_available: bool = True
     options: list[dict[str, Any]] = field(default_factory=list)
     recommended_option: str = ""
+
+    @property
+    def can_proceed(self) -> bool:
+        return (not self.needs_input) and self.action_needed == "proceed"
 
     def to_dict(self) -> dict[str, Any]:
         """Return a host-agent-friendly representation of the interaction."""
@@ -140,6 +144,7 @@ class InteractionResult:
             "llm_available": self.llm_available,
             "options": self.options,
             "recommended_option": self.recommended_option,
+            "can_proceed": self.can_proceed,
         }
 
 

--- a/scripts/core/data_gate.py
+++ b/scripts/core/data_gate.py
@@ -31,6 +31,7 @@ __all__ = [
 
 import json
 import logging
+import sys
 import time
 from dataclasses import dataclass, field
 from enum import Enum
@@ -249,7 +250,11 @@ class DataGate:
         return result
 
     def prompt_user(self) -> DataGateResult:
-        """CLI 模式：打印阻止信息，询问用户选择。"""
+        """CLI / Agent：打印阻止信息并处理选择。
+
+        TTY：input() 选 1/2/3。
+        非 TTY：写入 interaction.json 供宿主询问，不静默授权。
+        """
         result = self.check()
         if result.is_ready:
             print("\n✅ 数据验证通过，可以进入写作阶段。")
@@ -257,6 +262,36 @@ class DataGate:
 
         print(result.block_message)
         print("\n" + "─" * 60)
+
+        is_tty = False
+        try:
+            is_tty = bool(hasattr(sys.stdin, "isatty") and sys.stdin.isatty())
+        except Exception:
+            is_tty = False
+
+        if not is_tty:
+            payload = {
+                "needs_input": True,
+                "action_needed": "ask_data_gate",
+                "questions": [
+                    "数据门控未通过。请选择：1) 补充数据 2) 授权模拟数据 3) 退出",
+                ],
+                "options": [
+                    {"id": "1", "label": "补充缺失数据后重试"},
+                    {"id": "2", "label": "授权模拟数据（仅演示）"},
+                    {"id": "3", "label": "退出并保留会话"},
+                ],
+                "session_dir": str(self.session_dir),
+                "missing": result.missing,
+                "warnings": result.warnings,
+            }
+            inter_path = self.session_dir / "data_gate_interaction.json"
+            inter_path.parent.mkdir(parents=True, exist_ok=True)
+            inter_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2))
+            print("\n⚠️  非 TTY：已写入 data_gate_interaction.json，等待宿主向用户确认。")
+            print(f"   → {inter_path}")
+            return result
+
         try:
             choice = input("选择处理方式 [1/2/3]: ").strip()
         except (EOFError, KeyboardInterrupt):
@@ -279,7 +314,6 @@ class DataGate:
             }, ensure_ascii=False, indent=2))
             print("\n  ⚠️  已授权使用模拟数据（仅演示）→", auth_path)
             print("  ⚠️  生成的论文将包含模拟数字，不能用于发表")
-            # 重新检查：mock 阻断可被授权解除；缺失必需文件仍会挡住
             return self.check()
         elif choice == "3":
             print("\n  退出，当前会话保留在磁盘（可 resume）")

--- a/scripts/core/progressive_clarifier.py
+++ b/scripts/core/progressive_clarifier.py
@@ -176,7 +176,7 @@ class ProgressiveClarifier:
       1. 5 轮逐步澄清（不一次性接收所有信息）
       2. 每轮产物落盘到 output_dir/.clarify_session/XX_*.json
       3. 强制 ack：不调用 submit_answer()，禁止 advance()
-      4. 同步：每轮问完，CLI 调用 input()；AI agent 模式下返回 InteractionResult
+      4. 同步：每轮问完，CLI 调用 input()；AI agent 模式用 next_interaction()
     """
 
     def __init__(
@@ -190,7 +190,7 @@ class ProgressiveClarifier:
         Args:
             output_dir: 产物落盘目录，默认 output/.clarify_session/
             auto_ack: 仅用于测试；生产必须 False（强制用户确认）
-            cli_mode: True 阻塞 input；False 返回 InteractionResult
+            cli_mode: True 阻塞 input；False 时用 next_interaction()/submit_answer 驱动（不伪造 InteractionResult 类型）
         """
         self.output_dir = Path(output_dir) if output_dir else Path("output/.clarify_session")
         self.output_dir.mkdir(parents=True, exist_ok=True)
@@ -223,6 +223,37 @@ class ProgressiveClarifier:
         question = _STAGE_QUESTIONS[state.current_stage]
         options = self._extract_options(question)
         return (question, options)
+
+    def next_interaction(self, state: ClarificationState) -> dict[str, Any]:
+        """AI agent / 非 CLI：返回结构化 Interaction 载荷（非终端 input）。
+
+        返回 dict 兼容 ``InteractionResult.to_dict()`` 字段，避免循环导入
+        agent_pipeline。宿主应展示 questions/options，再调用 submit_answer + advance。
+        """
+        question, options = self.next_question(state)
+        if state.is_complete:
+            return {
+                "needs_input": False,
+                "action_needed": "proceed",
+                "questions": [question],
+                "options": [],
+                "recommended_option": "",
+                "stage": None,
+                "can_proceed": True,
+            }
+        opt_dicts = [
+            {"id": str(i), "label": opt}
+            for i, opt in enumerate(options, start=1)
+        ]
+        return {
+            "needs_input": True,
+            "action_needed": "ask_clarification",
+            "questions": [question],
+            "options": opt_dicts,
+            "recommended_option": opt_dicts[0]["id"] if opt_dicts else "",
+            "stage": state.current_stage.value,
+            "can_proceed": False,
+        }
 
     def submit_answer(self, state: ClarificationState, answer: str) -> None:
         """提交当前阶段的答案。
@@ -335,24 +366,25 @@ class ProgressiveClarifier:
     # ─── Interactive Run ───────────────────────────────────────────────────
 
     def run_interactive(self, topic: str) -> ResearchProfile:
-        """CLI 阻塞模式：自动 5 轮 input() 直到画像锁定。
-
-        Returns:
-            ResearchProfile: 锁定后的研究画像
-
-        Raises:
-            KeyboardInterrupt: 用户 Ctrl+C 中断（不会悄悄生成 mock）
-        """
+        """CLI 阻塞模式：从新会话开始 5 轮 input() 直到画像锁定。"""
         if not self.cli_mode:
             raise RuntimeError("run_interactive requires cli_mode=True")
-
         state = self.start(topic)
+        return self.run_interactive_from_state(state)
+
+    def run_interactive_from_state(self, state: ClarificationState) -> ResearchProfile:
+        """CLI 阻塞模式：从已有状态继续（用于 --resume，不调用 start 清空进度）。"""
+        if not self.cli_mode:
+            raise RuntimeError("run_interactive_from_state requires cli_mode=True")
+        if state.is_complete and state.profile is not None:
+            return state.profile
 
         print("\n" + "═" * 70)
-        print("  主题澄清（5 轮逐步引导）")
+        print("  主题澄清（逐步引导）")
         print("═" * 70)
-        print(f"\n  📌 研究主题: {topic}")
+        print(f"\n  📌 研究主题: {state.topic}")
         print(f"  📂 会话目录: {self.output_dir}")
+        print(f"  📈 进度: {state.progress_pct}% · 当前: {state.current_stage.value}")
         print(f"  ⏱️  开始时间: {time.strftime('%Y-%m-%d %H:%M:%S')}")
         print("\n  说明：每轮问一个问题，必须回答后才能进入下一轮。")
         print("        随时可输入 'quit' 退出（不会生成任何 mock 数据）。\n")
@@ -377,7 +409,6 @@ class ProgressiveClarifier:
                 raise KeyboardInterrupt("User quit")
 
             try:
-                # VENUE：若选大类 1/2，再追问具体刊名
                 if state.current_stage == ClarificationStage.VENUE:
                     answer = self._maybe_refine_venue_answer(answer)
                 self.submit_answer(state, answer)
@@ -387,12 +418,10 @@ class ProgressiveClarifier:
 
             state = self.advance(state)
 
-        # 画像锁定
         print("\n" + "═" * 70)
         print("  ✅ 研究画像已锁定")
         print("═" * 70)
         self._print_profile_summary(state.profile)
-
         return state.profile
 
     def _maybe_refine_venue_answer(self, answer: str) -> str:

--- a/scripts/health_check.py
+++ b/scripts/health_check.py
@@ -137,6 +137,7 @@ class ProblemCategory(str, Enum):
     DEPENDENCY = "dependency"
     MCP = "mcp"
     DATA_SOURCE = "data_source"
+    INFO = "info"
     OK = "ok"
 
 
@@ -508,12 +509,11 @@ def _check_llm(verify: bool = False) -> tuple[bool, str, list[ProblemItem]]:
         pass
 
     # ── Host Agent 委托检测（Cursor / Claude Code / Codex）──────────────────
-    # CLI 进程不能伪造对 host agent 的调用，但 host agent 可以在当前对话中
-    # 直接接管后续步骤。这里必须明确告知这一选项，不能把它描述成 Mock 降级。
+    # 信息提示，不是网络故障；不得计入 NETWORK 以免误判「LLM 不可用（网络问题）」。
     host_platform = _detect_platform()
     if host_platform in ("cursor", "claude_code", "codex"):
         problems.append(ProblemItem(
-            category=ProblemCategory.NETWORK,
+            category=ProblemCategory.INFO,
             name="HOST_AGENT_CONTEXT",
             name_zh="Host Agent 上下文",
             message=(
@@ -537,7 +537,10 @@ def _check_llm(verify: bool = False) -> tuple[bool, str, list[ProblemItem]]:
         status = "，".join(available)
         return True, f"✅ LLM 可用: {status}", problems
 
-    if ds_key and any(p.category == ProblemCategory.NETWORK for p in problems):
+    if ds_key and any(
+        p.category == ProblemCategory.NETWORK and p.name != "HOST_AGENT_CONTEXT"
+        for p in problems
+    ):
         return False, "❌ LLM 不可用（网络问题）", problems
 
     return False, "❌ 没有可用的 LLM（请配置 DEEPSEEK_API_KEY 或启动 ollama serve）", problems
@@ -1047,7 +1050,9 @@ def run_diagnostic(
                     ))
 
     # 4. 统计
-    counts: dict[str, int] = {"network": 0, "api_key": 0, "dependency": 0, "mcp": 0, "data_source": 0}
+    counts: dict[str, int] = {
+        "network": 0, "api_key": 0, "dependency": 0, "mcp": 0, "data_source": 0, "info": 0,
+    }
     for p in all_problems:
         cat_val = p.category.value if isinstance(p.category, ProblemCategory) else p.category
         counts[cat_val] = counts.get(cat_val, 0) + 1
@@ -1131,6 +1136,7 @@ _CAT_LABELS: dict[ProblemCategory, str] = {
     ProblemCategory.DEPENDENCY: "📦 依赖问题",
     ProblemCategory.MCP: "🖥️  MCP 配置",
     ProblemCategory.DATA_SOURCE: "📊 数据源问题",
+    ProblemCategory.INFO: "ℹ️  信息提示",
     ProblemCategory.OK: "✅ 无问题",
 }
 

--- a/scripts/idea_data_checker.py
+++ b/scripts/idea_data_checker.py
@@ -866,6 +866,41 @@ if __name__ == "__main__":
         Path(args.output).write_text(json.dumps(out, indent=2, ensure_ascii=False), encoding="utf-8")
         print(f"报告已写入: {args.output}")
 
-    # 退出码：0=全部可行, 1=部分/需授权, 2=全部不可行
-    sys.exit(0 if gap == 0 else (1 if feasible + partial > 0 else 2))
+    # 有缺口/需授权时：TTY 询问；非 TTY 输出 Interaction 载荷并以非 0 退出
+    needs_decision = gap > 0 or auth > 0
+    if needs_decision:
+        options = report.user_options or [
+            "1) 跳过缺口想法，仅保留可行/部分可行",
+            "2) 停止并补充数据",
+        ]
+        is_tty = hasattr(sys.stdin, "isatty") and sys.stdin.isatty()
+        if is_tty:
+            print()
+            print("下一步（请选择）：")
+            for opt in options:
+                print(f"  {opt}")
+            try:
+                choice = input("你的选择 [1/2，默认 2]: ").strip() or "2"
+            except (EOFError, KeyboardInterrupt):
+                choice = "2"
+            if choice not in ("1", "y", "yes", "skip", "是"):
+                print("已停止：存在数据缺口或需授权。")
+                sys.exit(2 if feasible + partial == 0 else 1)
+        else:
+            payload = {
+                "needs_input": True,
+                "action_needed": "ask_idea_data",
+                "questions": [
+                    f"有 {gap} 个数据缺口、{auth} 个需授权。请确认：跳过缺口继续，或停止补充数据。"
+                ],
+                "options": [{"id": str(i), "label": o} for i, o in enumerate(options, 1)],
+                "summary": {
+                    "total": total, "feasible": feasible,
+                    "partial": partial, "gap": gap, "requires_auth": auth,
+                },
+            }
+            print(json.dumps(payload, ensure_ascii=False, indent=2))
+            sys.exit(2 if feasible + partial == 0 else 1)
 
+    # 退出码：0=全部可行, 1=部分/需授权, 2=全部不可行
+    sys.exit(0 if gap == 0 and auth == 0 else (1 if feasible + partial > 0 else 2))

--- a/scripts/run_research.py
+++ b/scripts/run_research.py
@@ -199,15 +199,49 @@ def update_node_status(nodes: list, node_id: str, status: str,
 #  Agent Pipeline 包装
 # ═══════════════════════════════════════════════════════════════════════════════
 
-def run_agent_pipeline(topic: str) -> None:
+def _hitl_pause(stage_id: str, summary: str, *, use_hitl: bool) -> bool:
+    """阶段间 HITL。返回 True 继续，False 中止。
+
+    TTY：input 确认。非 TTY + HITL：默认中止（与 agent_pipeline fail-closed 对齐）；
+    设置 FINAI_NO_HITL=1 可跳过。
+    """
+    import os
+    import sys
+
+    if not use_hitl or os.environ.get("FINAI_NO_HITL") == "1":
+        return True
+    try:
+        tty = hasattr(sys.stdin, "isatty") and sys.stdin.isatty()
+    except Exception:
+        tty = False
+    if not tty:
+        log.error(
+            "HITL 已启用但非 TTY（阶段 %s）。已停止。"
+            "批处理请设 FINAI_NO_HITL=1，或使用 agent_pipeline --use-hitl。",
+            stage_id,
+        )
+        return False
+    print(f"\n🛑 HITL Gate · {stage_id}")
+    print(f"   {summary}")
+    print("   选项: c=continue / a=abort")
+    try:
+        choice = input("  你的选择 [c]: ").strip().lower() or "c"
+    except (EOFError, KeyboardInterrupt):
+        return False
+    return choice in {"c", "continue", "y", "yes", "是"}
+
+
+def run_agent_pipeline(topic: str, *, use_hitl: bool = True) -> None:
     """运行完整的 Agent Pipeline，实时推送状态到可视化服务器。"""
-    log.info("开始研究: %s", topic)
+    log.info("开始研究: %s (use_hitl=%s)", topic, use_hitl)
 
     # 构建初始状态并推送
     payload = build_initial_payload(topic)
     nodes = payload["nodes"]
     edges = payload["edges"]
     meta = payload["meta"]
+    meta["total_gates"] = 3 if use_hitl else 0
+    meta["hitl_enabled"] = use_hitl
 
     _push_wf_state(nodes, edges, meta)
     log.info("已推送初始状态: %d 个节点", len(nodes))
@@ -220,6 +254,8 @@ def run_agent_pipeline(topic: str) -> None:
             topic=topic,
             visualize=False,   # 我们自己推送状态
             auto_dashboard=False,
+            use_hitl=use_hitl,
+            hitl_stages=["outline", "literature", "draft"] if use_hitl else [],
         )
         pipeline = AgentPipeline(config=cfg)
 
@@ -248,6 +284,10 @@ def run_agent_pipeline(topic: str) -> None:
             log.warning("Outline agent failed: %s", e)
             update_node_status(nodes, "outline", "error", error=str(e))
         _push_wf_state(nodes, edges, meta)
+        if not _hitl_pause("outline", "大纲阶段完成，确认后继续文献综述", use_hitl=use_hitl):
+            meta["hitl_paused_at"] = "outline"
+            _push_wf_state(nodes, edges, meta)
+            return
 
         # ── Stage 2: Literature ───────────────────────────────────────────
         log.info("[2/5] 文献综述...")
@@ -274,6 +314,10 @@ def run_agent_pipeline(topic: str) -> None:
             log.warning("Literature agent failed: %s", e)
             update_node_status(nodes, "literature", "error", error=str(e))
         _push_wf_state(nodes, edges, meta)
+        if not _hitl_pause("literature", "文献综述完成，确认后继续图表/写作", use_hitl=use_hitl):
+            meta["hitl_paused_at"] = "literature"
+            _push_wf_state(nodes, edges, meta)
+            return
 
         # ── Stage 3: Plotting ───────────────────────────────────────────────
         log.info("[3/5] 图表生成...")
@@ -325,6 +369,10 @@ def run_agent_pipeline(topic: str) -> None:
             log.warning("Writing agent failed: %s", e)
             update_node_status(nodes, "writing", "error", error=str(e))
         _push_wf_state(nodes, edges, meta)
+        if not _hitl_pause("draft", "正文草稿完成，确认后继续润色", use_hitl=use_hitl):
+            meta["hitl_paused_at"] = "draft"
+            _push_wf_state(nodes, edges, meta)
+            return
 
         # ── Stage 5: Refinement ────────────────────────────────────────────
         log.info("[5/5] 修改润色...")
@@ -469,7 +517,7 @@ def consume_loop(poll_interval: float = POLL_INTERVAL) -> None:
             task_id = task.get("id", "?")
             log.info("取出任务 #%s: %s", task_id, topic[:50])
             try:
-                run_agent_pipeline(topic)
+                run_agent_pipeline(topic, use_hitl=True)
             except Exception as e:
                 log.error("任务 #%s 执行失败: %s", task_id, e)
                 import traceback
@@ -491,11 +539,17 @@ def main():
                         help="同时启动可视化服务器")
     parser.add_argument("--poll", type=float, default=POLL_INTERVAL,
                         help=f"队列轮询间隔（秒，默认 {POLL_INTERVAL}）")
+    parser.add_argument(
+        "--use-hitl",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="阶段间 HITL（默认开启；--no-use-hitl 或 FINAI_NO_HITL=1 关闭）",
+    )
     args = parser.parse_args()
 
     # 直接指定主题 → 立即执行
     if args.topic:
-        run_agent_pipeline(args.topic.strip())
+        run_agent_pipeline(args.topic.strip(), use_hitl=bool(args.use_hitl))
         return
 
     # 启动可视化服务器

--- a/scripts/start_research.py
+++ b/scripts/start_research.py
@@ -227,9 +227,9 @@ def cmd_resume(args) -> int:
         print("  ✅ 画像已锁定")
         return 0
 
-    # 继续澄清
+    # 继续澄清（从已恢复的 state 继续，禁止 start() 清空进度）
     try:
-        clarifier.run_interactive(state.topic)
+        clarifier.run_interactive_from_state(state)
     except KeyboardInterrupt:
         return 130
 

--- a/tests/test_pipeline_entry_fixes.py
+++ b/tests/test_pipeline_entry_fixes.py
@@ -102,6 +102,7 @@ class TestDataGateAuthorize:
         (data_dir / "panel_mock.csv").write_text("a,b\n1,2\n", encoding="utf-8")
 
         gate = DataGate(session_dir=tmp_path)
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
         monkeypatch.setattr("builtins.input", lambda *_a, **_k: "2")
         result = gate.prompt_user()
         auth = tmp_path / "authorized_synthetic.json"
@@ -183,4 +184,49 @@ class TestStartResearchNextSteps:
         assert "--stage novelty" not in src
         assert "--novelty-check" in src
         assert "literature_download.py" in src
+        assert "run_interactive_from_state" in src
         assert tq  # silence unused in lint tools
+
+
+class TestPost176Leftovers:
+    def test_host_agent_is_info_not_network(self):
+        from scripts.health_check import ProblemCategory
+
+        assert ProblemCategory.INFO.value == "info"
+        assert "HOST_AGENT" not in ProblemCategory.NETWORK.value
+
+    def test_interaction_can_proceed(self):
+        from scripts.agent_pipeline import InteractionResult
+
+        ok = InteractionResult(needs_input=False, action_needed="proceed")
+        assert ok.can_proceed is True
+        assert ok.to_dict()["can_proceed"] is True
+        blocked = InteractionResult(needs_input=True, action_needed="ask_api_key")
+        assert blocked.can_proceed is False
+
+    def test_next_interaction_payload(self, tmp_path):
+        from scripts.core.progressive_clarifier import ProgressiveClarifier
+
+        c = ProgressiveClarifier(output_dir=tmp_path, auto_ack=True, cli_mode=False)
+        state = c.start("主题")
+        payload = c.next_interaction(state)
+        assert payload["needs_input"] is True
+        assert payload["action_needed"] == "ask_clarification"
+        assert payload["questions"]
+
+    def test_data_gate_nontty_writes_interaction(self, tmp_path, monkeypatch):
+        from scripts.core.data_gate import DataGate
+
+        monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+        gate = DataGate(session_dir=tmp_path)
+        gate.prompt_user()
+        assert (tmp_path / "data_gate_interaction.json").exists()
+
+    def test_hitl_pause_nontty_aborts(self, monkeypatch):
+        from scripts import run_research as rr
+
+        monkeypatch.delenv("FINAI_NO_HITL", raising=False)
+        monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+        assert rr._hitl_pause("outline", "x", use_hitl=True) is False
+        monkeypatch.setenv("FINAI_NO_HITL", "1")
+        assert rr._hitl_pause("outline", "x", use_hitl=True) is True

--- a/tests/test_run_research_exec.py
+++ b/tests/test_run_research_exec.py
@@ -198,7 +198,10 @@ class TestMain:
         """Main with --topic runs the pipeline."""
         monkeypatch.setattr("sys.argv", ["run_research.py", "--topic", "Test topic"])
         called = []
-        monkeypatch.setattr(rr, "run_agent_pipeline", lambda t: called.append(t))
+        monkeypatch.setattr(
+            rr, "run_agent_pipeline",
+            lambda t, **kw: called.append(t),
+        )
         main()
         assert called == ["Test topic"]
 


### PR DESCRIPTION
## Summary
- `run_research.py`: default HITL pauses (outline/literature/draft); `--no-use-hitl` / `FINAI_NO_HITL=1` for batch
- `health_check`: HOST_AGENT is `INFO`, no longer false NETWORK / “LLM 网络问题”
- Clarifier: `next_interaction()` + `run_interactive_from_state()`; `--resume` no longer wipes progress
- DataGate / idea_data_checker: TTY asks; non-TTY writes structured interaction payload
- Docs/skills + `InteractionResult.can_proceed`

## Test plan
- [x] `pytest tests/test_pipeline_entry_fixes.py` (+ health/data_gate/run_research related)
- [ ] CI required checks


Made with [Cursor](https://cursor.com)