### PR TITLE
release: prepare 0.2.0a1 for clean PyPI Trusted Publishing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ set `FINAI_NO_HITL=1` or `--no-use-hitl` for batch. Do NOT auto-continue past a 
 | Run a specific method (DID/IV/RDD/PSM) | `python scripts/research_framework/modern_did.py --help` |
 | List journal templates | `python scripts/journal_template.py --list` |
 | List / register MCP servers | `python scripts/register_mcp_servers.py --list` / `--profile academic --prune` |
-| Verify project integrity | `python scripts/audit_guard.py` (17/17 checks) |
+| Verify project integrity | `python scripts/audit_guard.py` (25/25 checks) |
 
 ---
 
@@ -101,7 +101,7 @@ scripts/
 ├── research_framework/     # 47 econometric methods
 ├── core/                   # 87 modules (LLM, checkpoint, telemetry)
 ├── health_check.py         # System diagnostics
-├── audit_guard.py          # 17-check project integrity
+├── audit_guard.py          # 25-check project integrity
 ├── journal_template.py     # 30 journal templates
 ├── register_mcp_servers.py # 43 MCP servers
 └── universal_data_fetcher.py # 7-layer data fallback

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed (audit_fix_2026_07_12)
+## [0.2.0a1] - 2026-08-07
+
+### Fixed
+- Corrected maintainer docs: `audit_guard` check count 17→25, MCP directory count 50→43, and primary entry documented as `agent_pipeline.py` (not `agent.py`).
+- Fixed `Makefile` `pipeline-lit` target (removed nonexistent `--stage lit`; points to `literature_download.py`).
+
+### Changed
+- Cleared stale PyPI publish workflow waits for mismatched GitHub tags (`v1.0.0`/`v1.0.1`/`v0.2.0-alpha`) that would have uploaded wrong/conflicting package versions.
+- Bumped package version to `0.2.0a1` for a clean Trusted Publishing release aligned with `pyproject.toml`.
+
+### Fixed (audit_fix_2026_07_12, carried in tree)
 - **T001**: Removed mechanism tests from `scripts/us_esg_regression.py` that
   constructed `cds_proxy`, `rating_proxy`, and `analyst_cov_proxy` as linear
   functions of treatment variables (endless tautology — would mechanically

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,8 +4,8 @@ message: |
   Thanks for supporting open-source economic & financial research automation!
 type: software
 title: "FinAI Research Workflow"
-version: 0.2.0a0
-date-released: 2026-07-09
+version: 0.2.0a1
+date-released: 2026-08-07
 url: "https://github.com/csmar432/finai-research"
 repository-code: "https://github.com/csmar432/finai-research"
 repository: "https://github.com/csmar432/finai-research"

--- a/Makefile
+++ b/Makefile
@@ -84,8 +84,9 @@ demo:
 pipeline:
 	python scripts/agent_pipeline.py
 
+# agent_pipeline has no --stage flag; lit-only entry is literature_download.py
 pipeline-lit:
-	python scripts/agent_pipeline.py --stage lit
+	python scripts/literature_download.py
 
 # ─── Validation ────────────────────────────────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ pip install --break-system-packages "finai-research-workflow[extras]"
 > **重要提示**：缺少 `DEEPSEEK_API_KEY` 时，`finai-pipeline` 默认以退出码 4
 > 退出（严格模式），并打印明确指引。可以用 `finai-doctor` 诊断配置来源。
 
-> **PyPI:** [finai-research-workflow · 0.2.0a0](https://pypi.org/project/finai-research-workflow/) · MIT
+> **PyPI:** [finai-research-workflow · 0.2.0a1](https://pypi.org/project/finai-research-workflow/) · MIT
 > · 默认安装 `pip install finai-research-workflow` 不含 fastapi/streamlit（避免 PyJWT/apt 冲突）
 > · Web 套件：`pip install 'finai-research-workflow[web]'`
 > **DOI:** [10.5281/zenodo.21262689](https://doi.org/10.5281/zenodo.21262689)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # FinAI Research Workflow — Roadmap
 
 > Last updated: 2026-07-09
-> Status: v0.2.0a0
+> Status: v0.2.0a1
 
 This document outlines the development roadmap for FinAI Research Workflow.
 星标（Star）和社区反馈会优先影响 roadmap 优先级。
@@ -66,7 +66,7 @@ This document outlines the development roadmap for FinAI Research Workflow.
 ### High Priority
 | Item | Description | Ticket |
 |------|-------------|--------|
-| MCP tiering | Restructure 50 MCP dirs into Core/Recommended/Optional tiers | #TBD |
+| MCP tiering | Restructure 43 MCP dirs into Core/Recommended/Optional tiers | #TBD |
 | Demo GIF | Replace SVG/PNG with ≤15s GIF for README | #TBD |
 | Coverage +10% | Add tests for fin_charts, report_generator, robustness_runner | #TBD |
 | arXiv submission | Submit finai.pdf with revised abstract and case studies | #TBD |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "finai-research-workflow"
-version = "0.2.0a0"
+version = "0.2.0a1"
 description = "经济金融领域 AI 学术研究工作流 — 论文写作（JF/JFE/RFS/经济研究/金融研究）与金融研报生成。集成 MCP 数据获取、因果推断（DID/IV/PSM/GMM）、LaTeX 排版和对抗性 review 循环。"
 readme = "README.md"
 license = {text = "MIT"}

--- a/scripts/PROJECT_NUMBERS.json
+++ b/scripts/PROJECT_NUMBERS.json
@@ -6,8 +6,8 @@
   "generation_command": "python scripts/count_assets.py --sync-ssot",
   "_manual_overrides": {
     "_comment": "Fields below are NOT auto-detected by count_assets.py and require manual maintenance.",
-    "version.github_release": "v1.0.1 (Zenodo DOI 10.5281/zenodo.21262689, archive minted 2026-07-08)",
-    "version.pypi": "0.2.0a0 (published)"
+    "version.github_release": "v0.2.0a1 (Zenodo DOI 10.5281/zenodo.21262689 retained from prior archive)",
+    "version.pypi": "0.2.0a1 (publishing)"
   },
   "mcp": {
     "total_directories": 43,
@@ -131,10 +131,10 @@
     "chinese_guide_lines": 1049
   },
   "version": {
-    "pyproject": "0.2.0a0",
-    "github_release": "v1.0.1",
+    "pyproject": "0.2.0a1",
+    "github_release": "v0.2.0a1",
     "github_release_doi": "10.5281/zenodo.21262689",
-    "github_release_date": "2026-07-08",
-    "pypi": "0.2.0a0"
+    "github_release_date": "2026-08-07",
+    "pypi": "0.2.0a1"
   }
 }

--- a/scripts/SCRIPTS_INDEX.md
+++ b/scripts/SCRIPTS_INDEX.md
@@ -28,8 +28,8 @@
 
 || 脚本 | 命令 | 说明 |
 ||------|------|------|
-|| `agent.py` | `python scripts/agent.py` | 统一的 AI 研究 Agent CLI（主入口） |
-|| `agent_pipeline.py` | via `AI()` class | 5-Agent 流水线编排器（AgentPipeline 类，被其他模块导入） |
+|| `agent.py` | `python scripts/agent.py` | 单任务智能体入口（轻量；非端到端主入口） |
+|| `agent_pipeline.py` | `python scripts/agent_pipeline.py --topic "..." [--use-hitl]` | 端到端写作流水线主入口（AgentPipeline） |
 || `enhanced_workflow.py` | `python scripts/enhanced_workflow.py` | 增强研究工作流（含 HITL checkpoint） |
 || `interactive_paper_pipeline.py` | `python scripts/interactive_paper_pipeline.py` | 交互式论文写作（每个章节 checkpoint） |
 || `research_workflow.py` | — | **已废弃** → `deprecated/research_workflow.py`，使用 `agent_pipeline.py` |


### PR DESCRIPTION
## Summary
- Bump package version `0.2.0a0` → `0.2.0a1` (PyPI already has `0.2.0a0`)
- Sync SSOT / README / CITATION / CHANGELOG / ROADMAP
- Fix maintainer doc drift (audit_guard 25, MCP 43, entry=`agent_pipeline`)
- Fix Makefile `pipeline-lit` dead `--stage lit` flag

## Why
Stale Publish-to-PyPI runs were waiting on mismatched tags. This PR cuts a clean release path for Trusted Publishing.

## Test plan
- [x] Local `python -m build` → `0.2.0a1` sdist/wheel
- [x] `twine check` passed
- [x] `audit_guard.py --check 2,9,16` passed
- [ ] CI green
- [ ] After merge: tag `v0.2.0a1`, GitHub Release, approve `pypi` environment


Made with [Cursor](https://cursor.com)