### PR TITLE
chore: mark 0.2.0a1 published and fix Trusted Publishing docs

### DIFF
--- a/.github/REPOSITORY_METADATA.md
+++ b/.github/REPOSITORY_METADATA.md
@@ -114,11 +114,15 @@ Settings → Pages:
 
 ## 11. PyPI Trusted Publishing
 
-pypi.org/manage/account/publishing/ → Add a new pending publisher:
-- Owner: `csmar432`（或你的用户名）
-- Repository: `FinAI-Research-Workflow`
+pypi.org/manage/project/finai-research-workflow/settings/publishing/
+→ Add a trusted publisher (project already exists on PyPI):
+- Owner: `csmar432`
+- Repository: `finai-research`   # must match GitHub repo name exactly
 - Workflow filename: `publish-pypi.yml`
 - Environment name: `pypi`
+
+OIDC subject claim shape (for debugging):
+`repo:csmar432/finai-research:environment:pypi`
 
 无需 API token，GitHub Actions 用 OIDC 自动认证。
 

--- a/scripts/PROJECT_NUMBERS.json
+++ b/scripts/PROJECT_NUMBERS.json
@@ -7,7 +7,7 @@
   "_manual_overrides": {
     "_comment": "Fields below are NOT auto-detected by count_assets.py and require manual maintenance.",
     "version.github_release": "v0.2.0a1 (Zenodo DOI 10.5281/zenodo.21262689 retained from prior archive)",
-    "version.pypi": "0.2.0a1 (publishing)"
+    "version.pypi": "0.2.0a1 (published)"
   },
   "mcp": {
     "total_directories": 43,


### PR DESCRIPTION
## Summary
- Mark PyPI `0.2.0a1` as published in SSOT after successful Trusted Publishing upload
- Correct Trusted Publishing docs to use repo `finai-research` (not the old wrong name)

## Test plan
- [x] https://pypi.org/project/finai-research-workflow/0.2.0a1/ returns 200
- [x] Publish workflow run succeeded


Made with [Cursor](https://cursor.com)