### PR TITLE
fix: fail-closed agent-host entry for isolation slots

### DIFF
--- a/.agents/skills/fin-full-pipeline/SKILL.md
+++ b/.agents/skills/fin-full-pipeline/SKILL.md
@@ -9,6 +9,12 @@ argument-hint: "[research-direction]"
 
 端到端的经济金融学术研究流程，从用户描述研究方向开始，到生成可投稿论文 PDF 结束。
 
+> **Agent-host / 隔离槽位（重要）**  
+> 若任务要求「不要询问、不要 Mock、缺失配置则跳过并写报告」：  
+> **先运行** `python scripts/agent_host_entry.py`（或读取其写出的 `output/SKIPPED_CONFIG.md` / `output/FINAL.md`）。  
+> 若该入口因无 LLM 等原因以非 0 退出，**停止本 Skill**，不要自建平行复现流水线或编造结果。  
+> 交互式 HITL 路径仍用 `start_research.py` / `agent_pipeline.py --use-hitl`。
+
 ```
 研究方向输入
        ↓

--- a/.cursor/skills/fin-full-pipeline/SKILL.md
+++ b/.cursor/skills/fin-full-pipeline/SKILL.md
@@ -9,6 +9,11 @@ argument-hint: "[research-direction]"
 
 端到端的经济金融学术研究流程，从用户描述研究方向开始，到生成可投稿论文 PDF 结束。
 
+> **Agent-host / 隔离槽位（重要）**  
+> 若任务要求「不要询问、不要 Mock、缺失配置则跳过并写报告」：  
+> **先运行** `python scripts/agent_host_entry.py`。若非 0 退出，**停止本 Skill**，  
+> 不要自建平行复现流水线或编造结果。见 `AGENTS.md` → Agent-host protocol。
+
 ```
 研究方向输入
        ↓

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,8 +16,8 @@
 
 A finance & economics AI research workflow that automates the 8-stage research
 pipeline (idea → lit review → novelty → design → data → analysis → draft → review)
-with 43 MCP data sources, 47 econometric methods, 30 journal templates, and
-17 AI skills.
+with 43 MCP data sources, 58 econometric method modules, 30 journal templates, and
+18 AI skills.
 
 **Repo:** https://github.com/csmar432/finai-research
 **License:** MIT
@@ -42,7 +42,26 @@ python scripts/start_research.py --topic "Carbon trading and green innovation"
 
 # 3b. Direct writing pipeline
 python scripts/agent_pipeline.py --topic "Carbon trading and green innovation" --use-hitl
+
+# 3c. Agent-host / isolation slot (non-interactive, no Mock, fail-closed)
+#    Writes output/SKIPPED_CONFIG.md + output/FINAL.md when blocked (e.g. no LLM).
+#    Do NOT invent a parallel pipeline outside FinAI when this exits non-zero.
+python scripts/agent_host_entry.py --topic "Carbon trading and green innovation"
+# or: place TOPIC.md in cwd, then: python scripts/agent_host_entry.py
 ```
+
+---
+
+## Agent-host / isolation protocol
+
+When a host agent is told **not to ask**, **not to wait**, and **not to use Mock**:
+
+1. Prefer `python scripts/agent_host_entry.py` (reads `TOPIC.md` if `--topic` omitted).
+2. If the run is blocked (no LLM, missing topic, preflight refuse), **stop** after
+   `output/SKIPPED_CONFIG.md` + `output/FINAL.md` are written. Exit `4` = LLM/config block; `2` = bad/missing topic.
+3. **Do not** freestyle a second research stack, fabricate citations/coefficients, or silently enable Mock.
+4. Empirical work (DID/IV/data fetch) remains a **separate hand-off** from the writing pipeline; see dual-track notes in `docs/ARCHITECTURE.md`.
+5. Batch HITL off: default for `agent_host_entry`; or `FINAI_NO_HITL=1` / `--no-use-hitl` on other CLIs.
 
 ---
 
@@ -74,6 +93,7 @@ set `FINAI_NO_HITL=1` or `--no-use-hitl` for batch. Do NOT auto-continue past a 
 | Check system health | `python scripts/health_check.py` |
 | Clarify topic (5 rounds) | `python scripts/start_research.py --topic "..."` |
 | Run full pipeline | `python scripts/agent_pipeline.py --topic "..." --use-hitl` |
+| Agent-host batch (fail-closed) | `python scripts/agent_host_entry.py --topic "..."` |
 | Generate paper draft | `python scripts/research_framework/report_generator.py --outline FILE.md` |
 | Run a specific method (DID/IV/RDD/PSM) | `python scripts/research_framework/modern_did.py --help` |
 | List journal templates | `python scripts/journal_template.py --list` |
@@ -97,9 +117,10 @@ set `FINAI_NO_HITL=1` or `--no-use-hitl` for batch. Do NOT auto-continue past a 
 
 ```
 scripts/
-├── agent_pipeline.py       # Entry: full pipeline
-├── research_framework/     # 47 econometric methods
-├── core/                   # 87 modules (LLM, checkpoint, telemetry)
+├── agent_pipeline.py       # Entry: writing pipeline
+├── agent_host_entry.py     # Entry: non-interactive agent-host (SKIPPED/FINAL)
+├── research_framework/     # 58 econometric method modules
+├── core/                   # agent orchestration (LLM, checkpoint, telemetry)
 ├── health_check.py         # System diagnostics
 ├── audit_guard.py          # 25-check project integrity
 ├── journal_template.py     # 30 journal templates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Agent-host entry robustness**: isolation / non-interactive hosts previously had no
+  fail-closed FinAI entry when LLM was missing and Mock was forbidden, so agents
+  freestyled outside the official pipeline. Added `scripts/agent_host_entry.py` and
+  `scripts/core/agent_host_report.py` to write canonical `output/SKIPPED_CONFIG.md` +
+  `output/FINAL.md`, wired the same artifacts into `agent_pipeline` exit code 4, and
+  documented the protocol in `AGENTS.md` / `fin-full-pipeline` skill.
+
 ## [0.2.0a1] - 2026-08-07
 
 ### Fixed

--- a/knowledge/skills/fin-full-pipeline.md
+++ b/knowledge/skills/fin-full-pipeline.md
@@ -2,6 +2,9 @@
 
 > **注意**：本文件是文档版本。操作版本见 `.cursor/skills/fin-full-pipeline/SKILL.md`。
 
+> **Agent-host / 隔离槽位**：若要求不询问、不 Mock、缺失则跳过——先跑
+> `python scripts/agent_host_entry.py`；非 0 退出则停止，勿自建平行流水线。
+
 ## 功能
 
 端到端的经济金融学术研究流程：

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,6 +185,7 @@ finai-lit-review = "scripts.cli:lit_review_cmd"
 # 与 PyPI 包名同名的别名，方便 wheel 安装用户直接调用
 finai-research-workflow = "scripts.cli:pipeline_cmd_wrapper"
 finai-doctor = "scripts.cli:doctor_cmd"
+finai-agent-host = "scripts.agent_host_entry:main"
 
 [project.urls]
 Homepage = "https://github.com/csmar432/finai-research"

--- a/scripts/agent_host_entry.py
+++ b/scripts/agent_host_entry.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Agent-host / isolation-slot entry (non-interactive, fail-closed).
+
+Use when the host agent must:
+  - not ask the user
+  - not use Mock for research conclusions
+  - write output/SKIPPED_CONFIG.md + output/FINAL.md on blockers
+  - avoid inventing a parallel pipeline outside FinAI
+
+Examples:
+  python scripts/agent_host_entry.py
+  python scripts/agent_host_entry.py --topic "..." --output-dir output
+  FINAI_NO_HITL=1 python scripts/agent_host_entry.py --topic "..."
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts.core.agent_host_report import (  # noqa: E402
+    SkipItem,
+    blockers_from_diag,
+    write_blocked_run,
+)
+
+
+def _read_topic_md(cwd: Path) -> str:
+    for name in ("TOPIC.md", "topic.md"):
+        p = cwd / name
+        if p.is_file():
+            text = p.read_text(encoding="utf-8").strip()
+            if text:
+                # First non-empty, non-heading line as short topic; keep full text in report via file
+                for line in text.splitlines():
+                    s = line.strip()
+                    if not s or s.startswith("#"):
+                        continue
+                    return s[:300]
+                return text[:300]
+    return ""
+
+
+def _resolve_topic(arg_topic: str | None, cwd: Path) -> str:
+    if arg_topic and arg_topic.strip():
+        return arg_topic.strip()
+    from_md = _read_topic_md(cwd)
+    if from_md:
+        return from_md
+    return ""
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="FinAI agent-host entry: fail-closed, writes SKIPPED_CONFIG.md / FINAL.md",
+    )
+    parser.add_argument("--topic", default="", help="Research topic (else read TOPIC.md)")
+    parser.add_argument(
+        "--output-dir",
+        default="output",
+        help="Output directory for SKIPPED_CONFIG.md / FINAL.md / pipeline artifacts",
+    )
+    parser.add_argument(
+        "--venue",
+        default="",
+        help="Optional journal venue passed to agent_pipeline",
+    )
+    parser.add_argument(
+        "--allow-mock",
+        action="store_true",
+        help="Explicitly allow Mock (demo only; forbidden for real research isolation slots)",
+    )
+    parser.add_argument(
+        "--use-hitl",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="HITL gates (default off for agent-host batch; use --use-hitl to enable)",
+    )
+    parser.add_argument(
+        "--dry-run-preflight",
+        action="store_true",
+        help="Only run health/preflight and write skip/final reports; do not start writing pipeline",
+    )
+    args = parser.parse_args(argv)
+
+    cwd = Path.cwd()
+    topic = _resolve_topic(args.topic or None, cwd)
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    completed = ["Resolved working directory", f"Output dir → {output_dir}"]
+    if topic:
+        completed.append(f"Topic resolved → {topic[:120]}")
+    else:
+        write_blocked_run(
+            topic="",
+            output_dir=output_dir,
+            skipped=[
+                SkipItem(
+                    name="Topic",
+                    reason="No --topic and no TOPIC.md with usable content.",
+                    fix_hint="Pass --topic or create TOPIC.md in the working directory.",
+                )
+            ],
+            completed_steps=completed,
+            exit_code=2,
+        )
+        print("ERROR: missing topic (use --topic or TOPIC.md)", file=sys.stderr)
+        print(f"Wrote {output_dir / 'SKIPPED_CONFIG.md'} and {output_dir / 'FINAL.md'}")
+        return 2
+
+    # Health / LLM preflight (no MCP server start)
+    llm_available = False
+    llm_status = ""
+    try:
+        from scripts.health_check import run_diagnostic
+
+        diag = run_diagnostic()
+        llm_available = bool(diag.llm_available)
+        llm_status = getattr(diag, "llm_status", "") or ""
+        completed.append(
+            f"Health check → llm_available={llm_available}"
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        llm_available = False
+        llm_status = f"health_check failed: {exc}"
+        completed.append(llm_status)
+
+    allow_mock = bool(args.allow_mock) or os.environ.get("FINAI_ALLOW_MOCK") == "1"
+    skipped = blockers_from_diag(
+        llm_available=llm_available,
+        llm_status=llm_status,
+        allow_mock=allow_mock,
+    )
+
+    if skipped or args.dry_run_preflight:
+        # dry-run with healthy LLM still writes a progress FINAL (not blocked)
+        if args.dry_run_preflight and not skipped:
+            from scripts.core.agent_host_report import HostRunReport, write_host_reports
+
+            write_host_reports(
+                HostRunReport(
+                    topic=topic,
+                    output_dir=output_dir,
+                    status="partial",
+                    skipped=[],
+                    completed_steps=completed + ["dry-run-preflight: pipeline not started"],
+                    boundaries=[
+                        "Preflight only; writing/empirical pipeline not executed.",
+                    ],
+                    exit_code=0,
+                )
+            )
+            print(f"Preflight OK. Reports in {output_dir}")
+            return 0
+
+        write_blocked_run(
+            topic=topic,
+            output_dir=output_dir,
+            skipped=skipped
+            or [
+                SkipItem(
+                    name="dry-run",
+                    reason="--dry-run-preflight set",
+                    fix_hint="Omit --dry-run-preflight to run the writing pipeline.",
+                )
+            ],
+            completed_steps=completed,
+            exit_code=4 if skipped else 0,
+        )
+        print(
+            f"Blocked or dry-run. See {output_dir / 'SKIPPED_CONFIG.md'} "
+            f"and {output_dir / 'FINAL.md'}",
+            file=sys.stderr,
+        )
+        return 4 if skipped else 0
+
+    # Proceed with official writing pipeline (batch defaults)
+    from scripts.agent_pipeline import AgentPipeline, AgentPipelineConfig
+
+    if args.use_hitl:
+        os.environ.pop("FINAI_NO_HITL", None)
+    else:
+        os.environ.setdefault("FINAI_NO_HITL", "1")
+
+    config = AgentPipelineConfig(
+        topic=topic,
+        venue=args.venue or "通用",
+        use_hitl=bool(args.use_hitl),
+        hitl_stages=["outline", "literature", "draft"] if args.use_hitl else [],
+        allow_mock=allow_mock,
+        strict_llm=True,
+    )
+    pipeline = AgentPipeline(config=config)
+    result = pipeline.run(topic=topic, output_dir=str(output_dir / "fin-manuscript"))
+
+    interaction = getattr(result, "interaction", None)
+    if interaction is not None and not result.success and not getattr(
+        interaction, "llm_available", True
+    ):
+        write_blocked_run(
+            topic=topic,
+            output_dir=output_dir,
+            skipped=blockers_from_diag(
+                llm_available=False,
+                llm_status="agent_pipeline refused to start without LLM",
+                allow_mock=allow_mock,
+            ),
+            completed_steps=completed + ["agent_pipeline preflight refused run"],
+            exit_code=4,
+        )
+        return 4
+
+    if not result.success:
+        write_blocked_run(
+            topic=topic,
+            output_dir=output_dir,
+            skipped=[
+                SkipItem(
+                    name="agent_pipeline",
+                    reason="; ".join(result.errors[:5]) or "pipeline returned success=False",
+                    fix_hint="Inspect output/fin-manuscript and re-run with LLM configured.",
+                )
+            ],
+            completed_steps=completed + ["agent_pipeline started but did not fully succeed"],
+            exit_code=1,
+        )
+        return 1
+
+    from scripts.core.agent_host_report import HostRunReport, write_host_reports
+
+    write_host_reports(
+        HostRunReport(
+            topic=topic,
+            output_dir=output_dir,
+            status="completed",
+            skipped=[],
+            completed_steps=completed + ["agent_pipeline finished successfully"],
+            boundaries=[
+                "Writing pipeline artifacts are under output/fin-manuscript/.",
+                "Empirical DID/IV stages remain a separate hand-off "
+                "(research_framework / universal_data_fetcher).",
+            ],
+            exit_code=0,
+        )
+    )
+    print(f"✅ Agent-host run completed. See {output_dir / 'FINAL.md'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/agent_pipeline.py
+++ b/scripts/agent_pipeline.py
@@ -3338,6 +3338,36 @@ Examples:
     interaction = getattr(result, "interaction", None)
     if interaction and not result.success and not interaction.llm_available:
         print("\n⚠️  未运行流水线：请先选择一种 LLM 运行方式。")
+        # Agent-host isolation: leave canonical skip/progress artifacts so the
+        # host does not freestyle a parallel pipeline outside FinAI.
+        try:
+            from scripts.core.agent_host_report import (
+                blockers_from_diag,
+                write_blocked_run,
+            )
+
+            write_blocked_run(
+                topic=args.topic or config.topic or "",
+                output_dir=output_dir,
+                skipped=blockers_from_diag(
+                    llm_available=False,
+                    llm_status=(
+                        "; ".join(result.errors[:3])
+                        if result.errors
+                        else "LLM unavailable; mock disabled"
+                    ),
+                    allow_mock=bool(config.allow_mock),
+                ),
+                completed_steps=["agent_pipeline preflight (blocked)"],
+                entry="scripts/agent_pipeline.py",
+                exit_code=4,
+            )
+            print(
+                f"   已写入 {Path(output_dir) / 'SKIPPED_CONFIG.md'} "
+                f"与 {Path(output_dir) / 'FINAL.md'}"
+            )
+        except Exception as exc:  # noqa: BLE001 — never mask exit 4
+            print(f"   (skip-report write failed: {exc})", file=sys.stderr)
         return 4
     if result.success:
         print("\n✅ 流水线执行完成")

--- a/scripts/core/agent_host_report.py
+++ b/scripts/core/agent_host_report.py
@@ -11,6 +11,14 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Sequence
 
+__all__ = [
+    "SkipItem",
+    "HostRunReport",
+    "write_host_reports",
+    "blockers_from_diag",
+    "write_blocked_run",
+]
+
 
 @dataclass
 class SkipItem:

--- a/scripts/core/agent_host_report.py
+++ b/scripts/core/agent_host_report.py
@@ -1,0 +1,158 @@
+"""Canonical skip / progress reports for agent-host (non-interactive) runs.
+
+Isolation slots often require: no questions, no mock, write SKIPPED_CONFIG.md /
+FINAL.md, and stop cleanly when FinAI cannot proceed. Without these artifacts,
+host agents freestyle outside the official pipeline.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+
+@dataclass
+class SkipItem:
+    name: str
+    reason: str
+    fix_hint: str = ""
+
+
+@dataclass
+class HostRunReport:
+    topic: str
+    output_dir: Path
+    status: str  # "blocked" | "partial" | "completed"
+    skipped: list[SkipItem] = field(default_factory=list)
+    completed_steps: list[str] = field(default_factory=list)
+    boundaries: list[str] = field(default_factory=list)
+    entry: str = "scripts/agent_host_entry.py"
+    exit_code: int = 4
+
+    @property
+    def skipped_path(self) -> Path:
+        return self.output_dir / "SKIPPED_CONFIG.md"
+
+    @property
+    def final_path(self) -> Path:
+        return self.output_dir / "FINAL.md"
+
+
+def write_host_reports(report: HostRunReport) -> tuple[Path, Path]:
+    """Write SKIPPED_CONFIG.md and FINAL.md under output_dir. Returns paths."""
+    out = Path(report.output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+    skipped_lines = [
+        "# SKIPPED_CONFIG",
+        "",
+        f"> Generated: {ts}",
+        f"> Entry: `{report.entry}`",
+        f"> Topic: {report.topic or '(empty)'}",
+        f"> Status: **{report.status}**",
+        "",
+        "FinAI refused to invent Mock data, fake citations, or a parallel pipeline.",
+        "Items below were skipped because required configuration or tools are unavailable.",
+        "",
+    ]
+    if report.skipped:
+        skipped_lines += ["## Skipped items", ""]
+        for i, item in enumerate(report.skipped, 1):
+            skipped_lines.append(f"### {i}. {item.name}")
+            skipped_lines.append(f"- **Reason**: {item.reason}")
+            if item.fix_hint:
+                skipped_lines.append(f"- **Fix**: {item.fix_hint}")
+            skipped_lines.append("")
+    else:
+        skipped_lines += ["## Skipped items", "", "_None._", ""]
+
+    final_lines = [
+        "# FINAL — research progress report",
+        "",
+        f"> Generated: {ts}",
+        f"> Entry: `{report.entry}`",
+        f"> Topic: {report.topic or '(empty)'}",
+        f"> Status: **{report.status}**",
+        f"> Exit code: `{report.exit_code}`",
+        "",
+        "## Completed steps",
+        "",
+    ]
+    if report.completed_steps:
+        final_lines += [f"- {s}" for s in report.completed_steps]
+    else:
+        final_lines.append("- _(none — run blocked before research stages)_")
+    final_lines += ["", "## Boundaries / non-claims", ""]
+    bounds = list(report.boundaries) or [
+        "No Mock / synthetic research conclusions were produced.",
+        "No fabricated literature, coefficients, or citations were written.",
+        "Official FinAI writing pipeline was not started while blockers remain.",
+    ]
+    final_lines += [f"- {b}" for b in bounds]
+    final_lines += [
+        "",
+        "## Artifacts",
+        "",
+        f"- Skip log: `{report.skipped_path.name}`",
+        f"- This report: `{report.final_path.name}`",
+        "",
+        "## Next actions for the human operator",
+        "",
+        "1. Configure at least one LLM (`DEEPSEEK_API_KEY` or `RELAY_API_KEY` or Ollama).",
+        "2. Re-run: `python scripts/agent_host_entry.py --topic \"...\"`",
+        "3. Interactive path (human TTY): `python scripts/start_research.py --topic \"...\"`",
+        "",
+    ]
+
+    skipped_path = report.skipped_path
+    final_path = report.final_path
+    skipped_path.write_text("\n".join(skipped_lines), encoding="utf-8")
+    final_path.write_text("\n".join(final_lines), encoding="utf-8")
+    return skipped_path, final_path
+
+
+def blockers_from_diag(
+    *,
+    llm_available: bool,
+    llm_status: str = "",
+    allow_mock: bool = False,
+) -> list[SkipItem]:
+    """Map health/preflight signals to skip items."""
+    items: list[SkipItem] = []
+    if not llm_available and not allow_mock:
+        items.append(
+            SkipItem(
+                name="LLM / writing pipeline",
+                reason=llm_status
+                or "No external LLM configured and Ollama is not running; mock is disabled.",
+                fix_hint=(
+                    "Set DEEPSEEK_API_KEY or RELAY_API_KEY in .env.local, "
+                    "or run `ollama serve`. Do not use --allow-mock for real research."
+                ),
+            )
+        )
+    return items
+
+
+def write_blocked_run(
+    *,
+    topic: str,
+    output_dir: str | Path,
+    skipped: Sequence[SkipItem],
+    completed_steps: Sequence[str] | None = None,
+    entry: str = "scripts/agent_host_entry.py",
+    exit_code: int = 4,
+) -> HostRunReport:
+    report = HostRunReport(
+        topic=topic,
+        output_dir=Path(output_dir),
+        status="blocked",
+        skipped=list(skipped),
+        completed_steps=list(completed_steps or []),
+        entry=entry,
+        exit_code=exit_code,
+    )
+    write_host_reports(report)
+    return report

--- a/tests/test_agent_host_entry.py
+++ b/tests/test_agent_host_entry.py
@@ -1,0 +1,117 @@
+"""Tests for agent-host fail-closed entry and skip reports."""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def test_write_blocked_run_creates_artifacts(tmp_path: Path):
+    from scripts.core.agent_host_report import SkipItem, write_blocked_run
+
+    report = write_blocked_run(
+        topic="carbon trading",
+        output_dir=tmp_path,
+        skipped=[
+            SkipItem(
+                name="LLM",
+                reason="no key",
+                fix_hint="set DEEPSEEK_API_KEY",
+            )
+        ],
+        exit_code=4,
+    )
+    assert report.skipped_path.is_file()
+    assert report.final_path.is_file()
+    skipped = report.skipped_path.read_text(encoding="utf-8")
+    final = report.final_path.read_text(encoding="utf-8")
+    assert "SKIPPED_CONFIG" in skipped
+    assert "no key" in skipped
+    assert "DEEPSEEK_API_KEY" in skipped
+    assert "carbon trading" in final
+    assert "blocked" in final
+    assert "No Mock" in final
+
+
+def test_agent_host_entry_missing_topic(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.chdir(tmp_path)
+    from scripts.agent_host_entry import main
+
+    code = main(["--output-dir", str(tmp_path / "output")])
+    assert code == 2
+    assert (tmp_path / "output" / "SKIPPED_CONFIG.md").is_file()
+    assert (tmp_path / "output" / "FINAL.md").is_file()
+    assert "Topic" in (tmp_path / "output" / "SKIPPED_CONFIG.md").read_text()
+
+
+def test_agent_host_entry_reads_topic_md(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "TOPIC.md").write_text("# T\n\nAJR institutions and growth\n", encoding="utf-8")
+    from scripts.agent_host_entry import main
+
+    with patch("scripts.health_check.run_diagnostic") as diag:
+        diag.return_value = MagicMock(llm_available=False, llm_status="no llm")
+        code = main(["--output-dir", str(tmp_path / "output"), "--dry-run-preflight"])
+    assert code == 4
+    text = (tmp_path / "output" / "SKIPPED_CONFIG.md").read_text(encoding="utf-8")
+    assert "AJR institutions" in text or "LLM" in text
+    assert "FINAL.md" in (tmp_path / "output" / "FINAL.md").name
+
+
+def test_agent_host_entry_preflight_ok_dry_run(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.chdir(tmp_path)
+    from scripts.agent_host_entry import main
+
+    with patch("scripts.health_check.run_diagnostic") as diag:
+        diag.return_value = MagicMock(llm_available=True, llm_status="ok")
+        code = main(
+            [
+                "--topic",
+                "test topic",
+                "--output-dir",
+                str(tmp_path / "output"),
+                "--dry-run-preflight",
+            ]
+        )
+    assert code == 0
+    final = (tmp_path / "output" / "FINAL.md").read_text(encoding="utf-8")
+    assert "partial" in final
+    assert "Preflight" in final or "dry-run" in final
+
+
+def test_agent_pipeline_exit4_writes_skip_reports(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """CLI exit 4 path must leave SKIPPED_CONFIG.md for host agents."""
+    from scripts.agent_pipeline import (
+        AgentPipelineConfig,
+        AgentPipelineResult,
+        InteractionResult,
+    )
+    import scripts.agent_pipeline as ap
+
+    mock_pipeline = MagicMock()
+    mock_pipeline.run.return_value = AgentPipelineResult(
+        config=AgentPipelineConfig(topic="t"),
+        success=False,
+        errors=["no llm"],
+        interaction=InteractionResult(
+            needs_input=True,
+            action_needed="ask_llm_confirm",
+            llm_available=False,
+        ),
+    )
+    monkeypatch.setattr(ap, "AgentPipeline", lambda *a, **k: mock_pipeline)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "agent_pipeline.py",
+            "--topic",
+            "t",
+            "--output-dir",
+            str(tmp_path),
+        ],
+    )
+    code = ap.main()
+    assert code == 4
+    assert (tmp_path / "SKIPPED_CONFIG.md").is_file()
+    assert (tmp_path / "FINAL.md").is_file()


### PR DESCRIPTION
## Summary
User isolation-slot runs (no ask / no Mock / missing config → skip) had no robust FinAI entry: when LLM was unavailable, host agents abandoned `agent_pipeline` and freestyled parallel research stacks.

- Add `scripts/agent_host_entry.py` + `scripts/core/agent_host_report.py` → canonical `output/SKIPPED_CONFIG.md` + `output/FINAL.md`
- On `agent_pipeline` exit code 4 (no LLM), write the same artifacts
- Document protocol in `AGENTS.md` and `fin-full-pipeline` skill
- Console entry: `finai-agent-host`
- Tests: `tests/test_agent_host_entry.py` (5)

## Test plan
- [x] `pytest tests/test_agent_host_entry.py -q`
- [x] `python scripts/agent_host_entry.py --topic t --dry-run-preflight`
- [ ] CI green


Made with [Cursor](https://cursor.com)