### PR TITLE
fix: HITL after agent exec, reject rerun, revive PDF path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,12 @@ Use `python scripts/agent_pipeline.py --topic "..." --use-hitl` (defaults to
 outline/literature/draft gates). `run_research.py` also defaults to HITL;
 set `FINAI_NO_HITL=1` or `--no-use-hitl` for batch. Do NOT auto-continue past a stage.
 
+HITL protocol (`AgentOrchestrator` / `AgentPipeline`):
+1. Stage agent runs first; gate holds **after** output exists (review real content).
+2. `approve_step(stage)` then `resume_pipeline(paused)` → keep output, run next stage.
+3. `reject_step(stage, feedback)` then `resume_pipeline(paused)` → re-run same stage
+   with feedback injected; do not call resume while the gate is still PENDING.
+
 ---
 
 ## Key Entry Scripts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **HITL post-exec + resume semantics**: `AgentOrchestrator` previously called
+  `HITLGate.hold()` *before* `agent.run()`, so gated stages often never executed;
+  `resume_pipeline` also clamped/skipped incorrectly. Gates now hold **after**
+  real agent output (with `stage_result` in gate content). Approve continues from
+  the next step; reject re-runs the same stage with `prior_rejection_feedback`;
+  resume while still PENDING is a no-op (fail-closed). Prior stage results are
+  carried via `_resume_stage_results`.
+- **PDF / post-run bookkeeping dead path**: end-to-end TeX/PDF generation and
+  provenance/HITL bookkeeping lived under `_auto_generate_arch_diagrams` after
+  `return arch_paths` (unreachable). Moved into `AgentPipeline.run()` (and
+  mirrored on successful `resume_pipeline`), skipped while HITL-paused.
 - **Agent-host entry robustness**: isolation / non-interactive hosts previously had no
   fail-closed FinAI entry when LLM was missing and Mock was forbidden, so agents
   freestyled outside the official pipeline. Added `scripts/agent_host_entry.py` and
   `scripts/core/agent_host_report.py` to write canonical `output/SKIPPED_CONFIG.md` +
   `output/FINAL.md`, wired the same artifacts into `agent_pipeline` exit code 4, and
   documented the protocol in `AGENTS.md` / `fin-full-pipeline` skill.
+
+### Added
+- `tests/test_orchestrator_hitl_resume.py`: regression coverage for post-exec HITL,
+  approve→continue, reject→rerun+feedback, pending no-op, final-stage approve.
 
 ## [0.2.0a1] - 2026-08-07
 

--- a/scripts/agent_pipeline.py
+++ b/scripts/agent_pipeline.py
@@ -2099,17 +2099,17 @@ class AgentPipeline:
         # ── P0-1: End-to-end PDF / post-run bookkeeping ─────────────────────────
         # (Previously dead-indented under _auto_generate_arch_diagrams after
         # `return arch_paths` — never executed.)
-        paper_content: dict = {}
+        pdf_outline: dict = {}
         if result.outline:
-            paper_content.update(result.outline if isinstance(result.outline, dict) else {})
+            pdf_outline.update(result.outline if isinstance(result.outline, dict) else {})
         if result.writing:
             writing_data = result.writing if isinstance(result.writing, dict) else {}
-            paper_content.setdefault("content", writing_data)
+            pdf_outline.setdefault("content", writing_data)
         if result.refinement:
             refined = result.refinement if isinstance(result.refinement, dict) else {}
-            paper_content.setdefault("content", refined)
+            pdf_outline.setdefault("content", refined)
 
-        if _REPORT_GEN_AVAILABLE and paper_content and orchestrator_result.hitl_paused_at is None:
+        if _REPORT_GEN_AVAILABLE and pdf_outline and orchestrator_result.hitl_paused_at is None:
             import logging as _ap_log
             _ap_log = _ap_log.getLogger("agent_pipeline")
             try:
@@ -2117,7 +2117,7 @@ class AgentPipeline:
                 rg = ReportGenerator(output_dir=_out)
                 tex_path = rg.generate_paper(
                     topic=self.config.topic or "",
-                    outline=paper_content,
+                    outline=pdf_outline,
                     data=None,
                     regressions=None,
                     references=None,
@@ -2934,20 +2934,20 @@ class AgentPipeline:
             and orchestrator_result.hitl_paused_at is None
             and orchestrator_result.success
         ):
-            paper_content: dict = {}
+            resume_pdf_outline: dict = {}
             if result.outline and isinstance(result.outline, dict):
-                paper_content.update(result.outline)
+                resume_pdf_outline.update(result.outline)
             if result.writing and isinstance(result.writing, dict):
-                paper_content.setdefault("content", result.writing)
+                resume_pdf_outline.setdefault("content", result.writing)
             if result.refinement and isinstance(result.refinement, dict):
-                paper_content.setdefault("content", result.refinement)
-            if paper_content:
+                resume_pdf_outline.setdefault("content", result.refinement)
+            if resume_pdf_outline:
                 try:
                     _out = self.config.output_dir or "output/papers/"
                     rg = ReportGenerator(output_dir=_out)
                     tex_path = rg.generate_paper(
                         topic=self.config.topic or "",
-                        outline=paper_content,
+                        outline=resume_pdf_outline,
                         data=None,
                         regressions=None,
                         references=None,

--- a/scripts/agent_pipeline.py
+++ b/scripts/agent_pipeline.py
@@ -2096,7 +2096,116 @@ class AgentPipeline:
                 if arr:
                     result.auto_review_reports["refinement"] = arr
 
-        # ── DID Chart Auto-generation ─────────────────────────────────────────────
+        # ── P0-1: End-to-end PDF / post-run bookkeeping ─────────────────────────
+        # (Previously dead-indented under _auto_generate_arch_diagrams after
+        # `return arch_paths` — never executed.)
+        paper_content: dict = {}
+        if result.outline:
+            paper_content.update(result.outline if isinstance(result.outline, dict) else {})
+        if result.writing:
+            writing_data = result.writing if isinstance(result.writing, dict) else {}
+            paper_content.setdefault("content", writing_data)
+        if result.refinement:
+            refined = result.refinement if isinstance(result.refinement, dict) else {}
+            paper_content.setdefault("content", refined)
+
+        if _REPORT_GEN_AVAILABLE and paper_content and orchestrator_result.hitl_paused_at is None:
+            import logging as _ap_log
+            _ap_log = _ap_log.getLogger("agent_pipeline")
+            try:
+                _out = kwargs.get("output_dir") or self.config.output_dir or "output/papers/"
+                rg = ReportGenerator(output_dir=_out)
+                tex_path = rg.generate_paper(
+                    topic=self.config.topic or "",
+                    outline=paper_content,
+                    data=None,
+                    regressions=None,
+                    references=None,
+                    journal=self.config.venue or "经济研究",
+                    output_dir=_out,
+                )
+                result.paper_tex_path = str(tex_path)
+                _ap_log.info("Paper TeX/PDF generated: %s", tex_path)
+                pdf_path = Path(tex_path).with_suffix(".pdf")
+                if pdf_path.exists():
+                    _ap_log.info(
+                        "PDF available: %s (%.1f KB)",
+                        pdf_path,
+                        pdf_path.stat().st_size / 1024,
+                    )
+            except Exception as e:
+                _ap_log.warning("Paper PDF generation failed: %s", e)
+                result.errors.append(f"[PDF] generate_paper: {e}")
+
+        if self._evolution:
+            result.evolution_events = self._evolution.get_history()
+
+        if self._hitl_gate:
+            result.hitl_approvals = self._hitl_gate.get_history()
+
+        if _PROVENANCE_AVAILABLE and self.provenance_chain:
+            try:
+                self._register_provenance_result("outline", result.outline)
+                self._register_provenance_result("literature", result.literature)
+                self._register_provenance_result("plotting", result.plotting)
+                self._register_provenance_result("writing", result.writing)
+                self._register_provenance_result("refinement", result.refinement)
+            except Exception:  # noqa: S110
+                pass
+
+        if self.telemetry:
+            self.telemetry.ended_at = time.time()
+            try:
+                self.telemetry.save()
+            except Exception:  # noqa: S110
+                pass
+
+        if self.config.visualize:
+            result.visualization_path = self._generate_visualization(
+                steps, orchestrator_result
+            )
+
+        _wc = result.writing.get("total_word_count", 0) if isinstance(result.writing, dict) else 0
+        if _wc > 0 and _wc < 3000:
+            print(
+                f"\n⚠️  [字数警告] 论文正文仅 {_wc} 字，低于最低要求 3000 字。\n",
+                file=sys.stderr,
+            )
+            result.errors.append(f"[字数] 正文仅 {_wc} 字，低于 3000 字最低要求")
+
+        _pdf_err = [e for e in result.errors if "[PDF]" in e]
+        if _pdf_err and self._llm_actually_available:
+            print(
+                f"\n⚠️  [PDF] {' '.join(_pdf_err)}\n"
+                f"    请安装 LaTeX 工具链；.tex 文件可能已生成，可手动编译。\n",
+                file=sys.stderr,
+            )
+
+        if orchestrator_result.hitl_paused_at is not None:
+            result.success = False
+            result.errors.append(
+                f"HITL paused at {orchestrator_result.hitl_paused_at.value}; "
+                "call approve_step + resume_pipeline to continue."
+            )
+
+        _done_count = sum(
+            1 for s in orchestrator_result.stage_results.values()
+            if getattr(s, "status", None) in ("approved", "max_iterations", "ok", "success")
+        )
+        _total_count = len(steps)
+        _canvas_detail = f"总耗时: {(time.time() - start_time):.1f}s"
+        if orchestrator_result.hitl_paused_at:
+            _canvas_detail += f" | HITL@{orchestrator_result.hitl_paused_at.value}"
+        elif self._llm_actually_available:
+            _canvas_detail += " | LLM: 可用"
+        else:
+            _canvas_detail += " | ⚠️ LLM: Mock/受限"
+        _print_canvas_hint(
+            f"研究工作流{'暂停' if orchestrator_result.hitl_paused_at else '已完成'}！"
+            f"({_done_count}/{_total_count} 阶段)",
+            _canvas_detail,
+        )
+
         return result
 
     def _auto_generate_did_charts(
@@ -2263,119 +2372,6 @@ class AgentPipeline:
             _log_w.warning("[_auto_generate_arch_diagrams] Arch diagram generation failed: %s", ex)
 
         return arch_paths
-
-    # ── P0-1: End-to-end PDF generation ────────────────────────────────────
-        # Collect writing content for paper generation
-        paper_content: dict = {}
-        if result.outline:
-            paper_content.update(result.outline if isinstance(result.outline, dict) else {})
-        if result.writing:
-            writing_data = result.writing if isinstance(result.writing, dict) else {}
-            paper_content.setdefault("content", writing_data)
-        if result.refinement:
-            refined = result.refinement if isinstance(result.refinement, dict) else {}
-            paper_content.setdefault("content", refined)
-
-        if _REPORT_GEN_AVAILABLE and paper_content:
-            import logging as _ap_log
-            _ap_log = _ap_log.getLogger("agent_pipeline")
-            try:
-                output_dir = kwargs.get("output_dir") or self.config.output_dir or "output/papers/"
-                rg = ReportGenerator(output_dir=output_dir)
-                tex_path = rg.generate_paper(
-                    topic=self.config.topic or "",
-                    outline=paper_content,
-                    data=None,
-                    regressions=None,
-                    references=None,
-                    journal=self.config.venue or "经济研究",
-                    output_dir=output_dir,
-                )
-                result.paper_tex_path = str(tex_path)
-                _ap_log.info("Paper PDF generated: %s", tex_path)
-                pdf_path = tex_path.with_suffix(".pdf")
-                if pdf_path.exists():
-                    _ap_log.info("PDF available: %s (%.1f KB)",
-                                pdf_path, pdf_path.stat().st_size / 1024)
-            except Exception as e:
-                _ap_log.warning("Paper PDF generation failed: %s", e)
-                result.errors.append(f"[PDF] generate_paper: {e}")
-
-        # Evolution events
-        if self._evolution:
-            result.evolution_events = self._evolution.get_history()
-
-        # HITL approvals
-        if self._hitl_gate:
-            result.hitl_approvals = self._hitl_gate.get_history()
-
-        # ── Provenance: register final results ───────────────────────────────────
-        if _PROVENANCE_AVAILABLE and self.provenance_chain:
-            try:
-                self._register_provenance_result("outline", result.outline)
-                self._register_provenance_result("literature", result.literature)
-                self._register_provenance_result("plotting", result.plotting)
-                self._register_provenance_result("writing", result.writing)
-                self._register_provenance_result("refinement", result.refinement)
-            except Exception:  # noqa: S110  # pipeline must not crash on optional feature failures
-                pass
-
-        # ── Telemetry: record total duration ────────────────────────────────────
-        if self.telemetry:
-            self.telemetry.ended_at = time.time()
-            try:
-                self.telemetry.save()
-            except Exception:  # noqa: S110  # pipeline must not crash on optional feature failures
-                pass
-
-        # Visualization
-        if self.config.visualize:
-            result.visualization_path = self._generate_visualization(
-                steps, orchestrator_result
-            )
-
-        # ── P0-3: 字数校验 — 防止论文过短 ─────────────────────────────────
-        # 检查 writing 阶段输出是否达到最低字数要求（中文 CSSCI 通常 ≥8000 字）
-        _wc = result.writing.get("total_word_count", 0) if isinstance(result.writing, dict) else 0
-        if _wc > 0 and _wc < 3000:
-            import sys as _sys_wc
-            _warn_msg = (
-                f"\n⚠️  [字数警告] 论文正文仅 {_wc} 字，低于最低要求 3000 字。\n"
-                f"    建议增加引言、文献综述或机制分析章节内容。\n"
-                f"    如需完整论文草稿，请配置 DEEPSEEK_API_KEY 后重跑。\n"
-            )
-            print(_warn_msg, file=_sys_wc.stderr)
-            result.errors.append(f"[字数] 正文仅 {_wc} 字，低于 3000 字最低要求")
-
-        # ── P1-2: PDF 编译状态 — 缺少工具链时报错而非静默跳过 ───────────
-        _pdf_err = [e for e in result.errors if "[PDF]" in e]
-        if _pdf_err and self._llm_actually_available:
-            # LLM 生成了内容但 PDF 编译失败，打印警告
-            import sys as _sys_pdf
-            print(
-                f"\n⚠️  [PDF] {' '.join(_pdf_err)}\n"
-                f"    请安装 LaTeX 工具链（Mac: brew install --cask mactex；Linux: apt install texlive-full）\n"
-                f"    .tex 文件已生成，可手动编译。\n",
-                file=_sys_pdf.stderr,
-            )
-
-        # ── Canvas 可视化完成提示 ─────────────────────────────────────
-        _done_count = sum(
-            1 for s in orchestrator_result.stage_results.values()
-            if getattr(s, "status", None) == "approved"
-        )
-        _total_count = len(steps)
-        _canvas_detail = f"总耗时: {(time.time() - start_time):.1f}s"
-        if self._llm_actually_available:
-            _canvas_detail += " | LLM: 可用"
-        else:
-            _canvas_detail += " | ⚠️ LLM: 已授权 Mock（内容为模板，非真实论文）"
-        _print_canvas_hint(
-            f"研究工作流已完成！({_done_count}/{_total_count} 阶段)",
-            _canvas_detail,
-        )
-
-        return result
 
     def _is_interactive_terminal(self) -> bool:
         """判断是否可安全调用 input()。
@@ -2847,7 +2843,7 @@ class AgentPipeline:
 
         print()
         print(f"  阶段 '{stage.value}' 已拒绝。反馈：{feedback[:100]}")
-        print(f"  请修改内容后重新提交审批，或直接退出。")
+        print("  下一步：调用 resume_pipeline(paused_result) 将带着反馈重跑该阶段。")
         print()
 
         return result
@@ -2871,28 +2867,29 @@ class AgentPipeline:
 
     def resume_pipeline(self, paused_result) -> "AgentPipelineResult":
         """
-        Resume a HITL-paused pipeline after approval.
+        Resume a HITL-paused pipeline after approve_step / reject_step.
 
-        Usage:
-            # After user approves via approve_step():
-            result = pipeline.resume_pipeline(orchestrator_result)
+        - After approve: continues from the next stage (keeps approved output).
+        - After reject: re-runs the rejected stage with feedback injected.
+        - If the gate is still PENDING: returns the paused result unchanged.
         """
-        # Re-run orchestrator from the pause point
         if self._orchestrator is None:
             return AgentPipelineResult(
                 config=self.config,
                 success=False,
                 errors=["Orchestrator not initialized"],
             )
+        steps = self._current_steps or []
         orchestrator_result = self._orchestrator.resume_pipeline(
-            paused_result, self._current_steps
+            paused_result, steps
         )
 
-        # Extract results (same as run() for completed stages)
         result = AgentPipelineResult(
             config=self.config,
             orchestrator_result=orchestrator_result,
-            total_latency_ms=0.0,  # incremental
+            total_latency_ms=float(
+                getattr(orchestrator_result, "total_latency_ms", 0.0) or 0.0
+            ),
             success=orchestrator_result.success,
             llm_fallback_used=not self._llm_actually_available,
             llm_status=(
@@ -2903,18 +2900,70 @@ class AgentPipeline:
         )
 
         for stage, stage_result in orchestrator_result.stage_results.items():
-            stage_error = getattr(stage_result, 'error', None) or getattr(stage_result, 'err', None)
-            stage_status = getattr(stage_result, 'status', None)
+            stage_error = getattr(stage_result, "error", None) or getattr(
+                stage_result, "err", None
+            )
+            stage_status = getattr(stage_result, "status", None)
             if stage_error:
                 result.errors.append(f"[{stage}] {stage_error}")
             elif stage_status in ("failed", "error"):
-                result.errors.append(f"[{stage}] stage failed with status={stage_status}")
+                result.errors.append(
+                    f"[{stage}] stage failed with status={stage_status}"
+                )
 
+        if PipelineStage.OUTLINE in orchestrator_result.stage_results:
+            result.outline = orchestrator_result.stage_results[
+                PipelineStage.OUTLINE
+            ].output
+        if PipelineStage.LITERATURE in orchestrator_result.stage_results:
+            result.literature = orchestrator_result.stage_results[
+                PipelineStage.LITERATURE
+            ].output
         if PipelineStage.WRITING in orchestrator_result.stage_results:
-            result.writing = orchestrator_result.stage_results[PipelineStage.WRITING].output
-
+            result.writing = orchestrator_result.stage_results[
+                PipelineStage.WRITING
+            ].output
         if PipelineStage.REFINEMENT in orchestrator_result.stage_results:
-            result.refinement = orchestrator_result.stage_results[PipelineStage.REFINEMENT].output
+            result.refinement = orchestrator_result.stage_results[
+                PipelineStage.REFINEMENT
+            ].output
+
+        # Mirror run(): PDF only when the pipeline fully completes (no HITL pause).
+        if (
+            _REPORT_GEN_AVAILABLE
+            and orchestrator_result.hitl_paused_at is None
+            and orchestrator_result.success
+        ):
+            paper_content: dict = {}
+            if result.outline and isinstance(result.outline, dict):
+                paper_content.update(result.outline)
+            if result.writing and isinstance(result.writing, dict):
+                paper_content.setdefault("content", result.writing)
+            if result.refinement and isinstance(result.refinement, dict):
+                paper_content.setdefault("content", result.refinement)
+            if paper_content:
+                try:
+                    _out = self.config.output_dir or "output/papers/"
+                    rg = ReportGenerator(output_dir=_out)
+                    tex_path = rg.generate_paper(
+                        topic=self.config.topic or "",
+                        outline=paper_content,
+                        data=None,
+                        regressions=None,
+                        references=None,
+                        journal=self.config.venue or "经济研究",
+                        output_dir=_out,
+                    )
+                    result.paper_tex_path = str(tex_path)
+                except Exception as e:
+                    result.errors.append(f"[PDF] generate_paper: {e}")
+
+        if orchestrator_result.hitl_paused_at is not None:
+            result.success = False
+            result.errors.append(
+                f"HITL paused at {orchestrator_result.hitl_paused_at.value}; "
+                "call approve_step/reject_step + resume_pipeline to continue."
+            )
 
         return result
 

--- a/scripts/core/orchestrator.py
+++ b/scripts/core/orchestrator.py
@@ -51,7 +51,7 @@ from scripts.core.agents.base import (
     CancellationToken,
     HaltDecision,
 )
-from scripts.core.hitl_gate import HITLGate
+from scripts.core.hitl_gate import GateState, HITLGate
 from scripts.core.agent_state import hitl_manager
 from scripts.core.llm_gateway import LLMGateway
 
@@ -527,6 +527,12 @@ class AgentOrchestrator:
         """
         Resume a HITL-paused pipeline after approval or rejection.
 
+        Semantics (HITL holds *after* the agent produces output):
+        - APPROVED → keep the paused stage output, continue from the next step
+        - REJECTED → drop the rejected output, re-run the same stage with
+          ``prior_rejection_feedback`` injected from ``reject_step()``
+        - PENDING / undecided → return ``paused_result`` unchanged (fail-closed)
+
         Parameters
         ----------
         paused_result : PipelineResult
@@ -545,31 +551,89 @@ class AgentOrchestrator:
 
         paused_stage = paused_result.hitl_paused_at
 
-        # Build context carrying over completed stage results
-        resume_context = dict(paused_result.final_context)
-        # Inject completed stage outputs so downstream stages can access them
-        for stage, result in paused_result.stage_results.items():
-            resume_context[f"{stage.value}_result"] = result.output
-
-        # Find index of the paused stage and resume from the next one
-        resume_idx = 0
-        for i, step in enumerate(steps):
-            if step.stage == paused_stage:
-                resume_idx = i + 1  # skip the paused stage itself, resume from next
-                break
-
-        # Clamp to valid range
-        resume_idx = min(resume_idx, len(steps) - 1)
-        if resume_idx >= len(steps):
+        # Fail-closed: still waiting for a human decision.
+        still_pending = [
+            r for r in self._hitl_gate.get_pending()
+            if r.stage == paused_stage.value
+        ]
+        if still_pending:
             logger.warning(
-                f"resume_pipeline: all steps completed (resume_idx={resume_idx} >= len(steps)={len(steps)}), "
-                "returning existing paused_result"
+                "resume_pipeline: stage %s still PENDING — approve/reject first",
+                paused_stage.value,
             )
             return paused_result
 
+        history = self._hitl_gate.get_history(stage=paused_stage.value, limit=1)
+        if not history:
+            logger.warning(
+                "resume_pipeline: no decision recorded for stage %s",
+                paused_stage.value,
+            )
+            return paused_result
+
+        decision = history[-1]
+        paused_idx = next(
+            (i for i, step in enumerate(steps) if step.stage == paused_stage),
+            None,
+        )
+        if paused_idx is None:
+            logger.warning(
+                "resume_pipeline: paused stage %s not in steps",
+                paused_stage.value,
+            )
+            return paused_result
+
+        resume_context = dict(paused_result.final_context)
+        for stage, result in paused_result.stage_results.items():
+            resume_context[f"{stage.value}_result"] = result.output
+        carried_results = dict(paused_result.stage_results)
+
+        if decision.state == GateState.REJECTED:
+            # Re-run the rejected stage with stored feedback.
+            resume_idx = paused_idx
+            carried_results.pop(paused_stage, None)
+            resume_context.pop(f"{paused_stage.value}_result", None)
+            action = "rejected→rerun"
+        elif decision.state == GateState.APPROVED:
+            resume_idx = paused_idx + 1
+            action = "approved→continue"
+        else:
+            logger.warning(
+                "resume_pipeline: unexpected gate state %s for %s",
+                decision.state,
+                paused_stage.value,
+            )
+            return paused_result
+
+        if resume_idx >= len(steps):
+            # Last stage was approved — nothing left to run.
+            logger.info(
+                "resume_pipeline: '%s' approved final stage %s; pipeline complete",
+                paused_result.pipeline_name,
+                paused_stage.value,
+            )
+            return PipelineResult(
+                pipeline_name=paused_result.pipeline_name,
+                success=True,
+                stage_results=carried_results,
+                final_context=resume_context,
+                total_latency_ms=paused_result.total_latency_ms,
+                hitl_paused_at=None,
+                evolution_events=list(paused_result.evolution_events),
+                trace=list(paused_result.trace) + [{
+                    "type": "hitl_resume_complete",
+                    "stage": paused_stage.value,
+                    "action": action,
+                    "timestamp": time.time(),
+                }],
+            )
+
         logger.info(
-            f"Resuming pipeline '{paused_result.pipeline_name}' "
-            f"from step {resume_idx} ({paused_stage.value} approved)"
+            "Resuming pipeline '%s' from step %s (%s %s)",
+            paused_result.pipeline_name,
+            resume_idx,
+            paused_stage.value,
+            action,
         )
 
         return self._run_pipeline_impl(
@@ -580,6 +644,7 @@ class AgentOrchestrator:
             max_workers=4,
             _resume_from_step=resume_idx,
             _resume_context=resume_context,
+            _resume_stage_results=carried_results,
         )
 
     def run_parallel(
@@ -716,6 +781,7 @@ class AgentOrchestrator:
         max_workers: int = 4,
         _resume_from_step: int = 0,
         _resume_context: dict[str, Any] | None = None,
+        _resume_stage_results: dict[PipelineStage, AgentResult] | None = None,
     ) -> PipelineResult:
         """
         Internal pipeline execution (also used for HITL resume).
@@ -726,6 +792,9 @@ class AgentOrchestrator:
             Index of the step to resume from (used after HITL approval).
         _resume_context : dict | None
             Pre-built context to continue from (replaces rebuilding from input_data).
+        _resume_stage_results : dict | None
+            Stage results already produced before the HITL pause (must be
+            carried forward so success aggregation stays correct).
         """
         # Check if parliament integration is available
         _has_parliament = False
@@ -743,7 +812,9 @@ class AgentOrchestrator:
         else:
             context = dict(input_data)
 
-        stage_results: dict[PipelineStage, AgentResult] = {}
+        stage_results: dict[PipelineStage, AgentResult] = (
+            dict(_resume_stage_results) if _resume_stage_results else {}
+        )
         hitl_paused_at: PipelineStage | None = None
 
         for step in steps[_resume_from_step:]:
@@ -790,13 +861,11 @@ class AgentOrchestrator:
                 )
                 continue
 
-            # Build agent_context BEFORE the HITL gate so it is in scope
             # Inject any prior rejection feedback so the agent can improve
             agent_context = {
                 **context,
                 "messages": self.get_messages(step.agent_name),
             }
-            # Inject rejection feedback from previous rejection
             if step.stage.value in self._rejection_feedback:
                 prior_feedback = self._rejection_feedback.pop(step.stage.value)
                 agent_context["prior_rejection_feedback"] = prior_feedback
@@ -805,48 +874,7 @@ class AgentOrchestrator:
                     "content": f"[审核反馈] 上一轮审核未通过，请根据以下反馈改进：{prior_feedback}",
                 })
 
-            # ── HITL Gate ─────────────────────────────────────────────────
-            if step.hitl_gate:
-                # Build enriched gate content with parliament verdict
-                # Note: 'result' is not yet defined here (agent hasn't run yet);
-                # use context (accumulated stage results) instead of result.output
-                gate_content = {
-                    "context": agent_context,
-                    "result_preview": str(context)[:500],
-                    "stage_result": context.get(f"{step.stage.value}_result"),
-                }
-                if hasattr(self, "_pending_parliament_verdict"):
-                    gate_content["parliament_verdict"] = self._pending_parliament_verdict
-                gate_id = self._hitl_gate.hold(
-                    stage=step.stage.value,
-                    content=gate_content,
-                    question=f"请审核 {step.stage.value} 阶段的输出并决定是否继续。",
-                )
-                hitl_paused_at = step.stage
-                # Also register globally so SSE/web UI can see it
-                self._shared_hitl.create_request(
-                    agent_id=step.agent_name,
-                    task_id=gate_id,
-                    decision_point=step.stage.value,
-                    context={"context": agent_context, "result_preview": str(context)[:500]},
-                )
-                self._trace.append({
-                    "type": "hitl_pause",
-                    "stage": step.stage.value,
-                    "context_preview": str(context)[:200],
-                    "timestamp": time.time(),
-                })
-                return PipelineResult(
-                    pipeline_name=pipeline_name,
-                    success=False,
-                    stage_results=stage_results,
-                    final_context=context,
-                    total_latency_ms=(time.time() - start_time) * 1000,
-                    hitl_paused_at=hitl_paused_at,
-                    trace=self._trace,
-                )
-
-            # ── Execute Agent ───────────────────────────────────────────────
+            # ── Execute Agent (before HITL so humans review real output) ──
             self._trace.append({
                 "type": "agent_start",
                 "stage": step.stage.value,
@@ -885,10 +913,7 @@ class AgentOrchestrator:
                 "status": result.status,
             })
 
-            # ── Parliament Review (before HITL gate) ─────────────────────────
-            # Run AI parliament review AFTER stage execution but BEFORE the
-            # HITL approval gate is created, so the verdict is available to
-            # the human reviewer.
+            # ── Parliament Review (feeds HITL content) ───────────────────
             if _has_parliament and step.hitl_gate:
                 try:
                     import asyncio as _asyncio
@@ -943,13 +968,59 @@ class AgentOrchestrator:
             if result.status == "error":
                 break
 
-        total_latency_ms = (time.time() - start_time) * 1000
+            # ── HITL Gate (after agent output exists) ─────────────────────
+            if step.hitl_gate:
+                preview = str(result.output)[:500]
+                gate_content = {
+                    "context": {k: v for k, v in agent_context.items() if k != "messages"},
+                    "result_preview": preview,
+                    "stage_result": result.output,
+                    "agent_status": result.status,
+                }
+                if getattr(self, "_pending_parliament_verdict", None):
+                    gate_content["parliament_verdict"] = self._pending_parliament_verdict
+                gate_id = self._hitl_gate.hold(
+                    stage=step.stage.value,
+                    content=gate_content,
+                    question=f"请审核 {step.stage.value} 阶段的输出并决定是否继续。",
+                )
+                hitl_paused_at = step.stage
+                self._shared_hitl.create_request(
+                    agent_id=step.agent_name,
+                    task_id=gate_id,
+                    decision_point=step.stage.value,
+                    context={
+                        "result_preview": preview,
+                        "agent_status": result.status,
+                    },
+                )
+                self._trace.append({
+                    "type": "hitl_pause",
+                    "stage": step.stage.value,
+                    "result_preview": preview[:200],
+                    "timestamp": time.time(),
+                })
+                return PipelineResult(
+                    pipeline_name=pipeline_name,
+                    success=False,
+                    stage_results=stage_results,
+                    final_context=context,
+                    total_latency_ms=(time.time() - start_time) * 1000,
+                    hitl_paused_at=hitl_paused_at,
+                    trace=self._trace,
+                )
 
+        total_latency_ms = (time.time() - start_time) * 1000
+        expected_steps = [s for s in steps if not s.skip]
         return PipelineResult(
             pipeline_name=pipeline_name,
             success=hitl_paused_at is None
-            and len(stage_results) == len([s for s in steps if not s.skip])
-            and all(r.status != "error" for r in stage_results.values()),
+            and len(stage_results) >= len(expected_steps)
+            and all(
+                stage_results.get(s.stage) is not None
+                and stage_results[s.stage].status != "error"
+                for s in expected_steps
+            ),
             stage_results=stage_results,
             final_context=context,
             total_latency_ms=total_latency_ms,

--- a/tests/test_orchestrator_hitl_resume.py
+++ b/tests/test_orchestrator_hitl_resume.py
@@ -1,0 +1,153 @@
+"""Regression: HITL holds AFTER agent.run, approve advances, reject re-runs."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scripts.core.agents.base import AgentResult
+from scripts.core.hitl_gate import GateState, HITLGate
+from scripts.core.orchestrator import (
+    AgentOrchestrator,
+    PipelineStage,
+    PipelineStep,
+)
+
+
+def _make_agent(name: str, output: dict, call_log: list[str]):
+    agent = MagicMock()
+    agent.config = MagicMock()
+    agent.config.name = name
+
+    def _run(ctx, cancel_token=None):
+        call_log.append(name)
+        # Capture rejection feedback when present (reject→rerun path).
+        if ctx.get("prior_rejection_feedback"):
+            call_log.append(f"feedback:{ctx['prior_rejection_feedback']}")
+        return AgentResult(status="approved", output=dict(output), stage=name)
+
+    agent.run = _run
+    return agent
+
+
+@pytest.fixture
+def orch(tmp_path):
+    with patch("scripts.core.orchestrator.LLMGateway"):
+        o = AgentOrchestrator(gateway=None)
+    o.set_hitl_gate(HITLGate(db_path=str(tmp_path / "hitl.db")))
+    return o
+
+
+def test_hitl_runs_agent_before_hold(orch):
+    """Gate must see real agent output — not pause before execution."""
+    calls: list[str] = []
+    orch._agents["outline"] = _make_agent("outline", {"title": "T"}, calls)
+    orch._agents["writing"] = _make_agent("writing", {"body": "B"}, calls)
+
+    steps = [
+        PipelineStep(stage=PipelineStage.OUTLINE, agent_name="outline", hitl_gate=True),
+        PipelineStep(
+            stage=PipelineStage.WRITING,
+            agent_name="writing",
+            depends_on=[PipelineStage.OUTLINE],
+            hitl_gate=False,
+        ),
+    ]
+    result = orch.run_pipeline("t", steps, {"topic": "x"})
+
+    assert calls == ["outline"]
+    assert result.hitl_paused_at == PipelineStage.OUTLINE
+    assert result.success is False
+    assert PipelineStage.OUTLINE in result.stage_results
+    assert result.stage_results[PipelineStage.OUTLINE].output["title"] == "T"
+    pending = orch._hitl_gate.get_pending()
+    assert len(pending) == 1
+    assert pending[0].content.get("stage_result", {}).get("title") == "T"
+
+
+def test_approve_then_resume_skips_rerun_and_continues(orch):
+    calls: list[str] = []
+    orch._agents["outline"] = _make_agent("outline", {"title": "T"}, calls)
+    orch._agents["writing"] = _make_agent("writing", {"body": "B"}, calls)
+
+    steps = [
+        PipelineStep(stage=PipelineStage.OUTLINE, agent_name="outline", hitl_gate=True),
+        PipelineStep(
+            stage=PipelineStage.WRITING,
+            agent_name="writing",
+            depends_on=[PipelineStage.OUTLINE],
+            hitl_gate=False,
+        ),
+    ]
+    paused = orch.run_pipeline("t", steps, {"topic": "x"})
+    assert paused.hitl_paused_at == PipelineStage.OUTLINE
+
+    orch.approve_step(PipelineStage.OUTLINE, feedback="ok")
+    resumed = orch.resume_pipeline(paused, steps)
+
+    assert calls == ["outline", "writing"]  # outline not re-run
+    assert resumed.hitl_paused_at is None
+    assert resumed.success is True
+    assert resumed.stage_results[PipelineStage.OUTLINE].output["title"] == "T"
+    assert resumed.stage_results[PipelineStage.WRITING].output["body"] == "B"
+
+
+def test_reject_then_resume_reruns_same_stage_with_feedback(orch):
+    calls: list[str] = []
+    orch._agents["outline"] = _make_agent("outline", {"title": "v2"}, calls)
+    orch._agents["writing"] = _make_agent("writing", {"body": "B"}, calls)
+
+    steps = [
+        PipelineStep(stage=PipelineStage.OUTLINE, agent_name="outline", hitl_gate=True),
+        PipelineStep(
+            stage=PipelineStage.WRITING,
+            agent_name="writing",
+            depends_on=[PipelineStage.OUTLINE],
+            hitl_gate=False,
+        ),
+    ]
+    paused = orch.run_pipeline("t", steps, {"topic": "x"})
+    orch.reject_step(PipelineStage.OUTLINE, feedback="add methods chapter")
+
+    # Still paused until resume; decision is REJECTED.
+    hist = orch._hitl_gate.get_history(stage="outline", limit=1)
+    assert hist and hist[-1].state == GateState.REJECTED
+
+    resumed = orch.resume_pipeline(paused, steps)
+
+    # outline ran twice; second call received rejection feedback.
+    assert calls[0] == "outline"
+    assert "feedback:add methods chapter" in calls
+    assert calls.count("outline") == 2
+    assert resumed.hitl_paused_at == PipelineStage.OUTLINE  # HITL again after re-run
+    assert PipelineStage.OUTLINE in resumed.stage_results
+
+
+def test_resume_while_pending_is_noop(orch):
+    calls: list[str] = []
+    orch._agents["outline"] = _make_agent("outline", {"title": "T"}, calls)
+    steps = [
+        PipelineStep(stage=PipelineStage.OUTLINE, agent_name="outline", hitl_gate=True),
+    ]
+    paused = orch.run_pipeline("t", steps, {"topic": "x"})
+    again = orch.resume_pipeline(paused, steps)
+    assert again is paused or again.hitl_paused_at == PipelineStage.OUTLINE
+    assert calls == ["outline"]  # no second run
+
+
+def test_approve_final_stage_completes_without_rerun(orch):
+    calls: list[str] = []
+    orch._agents["outline"] = _make_agent("outline", {"title": "T"}, calls)
+    steps = [
+        PipelineStep(stage=PipelineStage.OUTLINE, agent_name="outline", hitl_gate=True),
+    ]
+    paused = orch.run_pipeline("t", steps, {"topic": "x"})
+    orch.approve_step(PipelineStage.OUTLINE)
+    done = orch.resume_pipeline(paused, steps)
+    assert done.success is True
+    assert done.hitl_paused_at is None
+    assert calls == ["outline"]
+    assert any(
+        e.get("type") == "hitl_resume_complete" for e in done.trace
+    )


### PR DESCRIPTION
## Summary
- Fix `AgentOrchestrator` HITL to hold **after** `agent.run()` so gated stages actually execute and reviewers see real `stage_result` content.
- Resume semantics: approve → next step; reject → re-run same stage with `prior_rejection_feedback`; PENDING resume is a no-op (fail-closed); carry prior results via `_resume_stage_results`.
- Move unreachable TeX/PDF + post-run bookkeeping out of `_auto_generate_arch_diagrams` into `AgentPipeline.run()` / successful `resume_pipeline` (skip while HITL-paused).
- Add `tests/test_orchestrator_hitl_resume.py` and document the HITL protocol in `AGENTS.md` / `CHANGELOG.md`.

## Test plan
- [x] `pytest tests/test_orchestrator_hitl_resume.py tests/test_orchestrator_comprehensive.py -q` (56 passed)
- [ ] CI green on PR
- [ ] Manual smoke (optional): `agent_pipeline --use-hitl` → pause with real outline → approve → continue; reject → rerun with feedback


Made with [Cursor](https://cursor.com)