### PR TITLE
fix: CLI compat, writing pre-gate soft-skip, CI coverage tests

### DIFF
--- a/.claude/commands/lit-review.md
+++ b/.claude/commands/lit-review.md
@@ -13,7 +13,8 @@ description: 对指定研究主题进行系统性文献综述，构建引文网�
 等价于：
 
 ```bash
-python scripts/research_framework/pipeline.py --mode lit-review --topic "<topic>"
+python scripts/literature_download.py "<topic>" --source arxiv,semantic,openalex --limit 25
+# or Skill: fin-lit-review
 ```
 
 # MCP 数据源

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Writing pre-gate compat**: stop inventing `baseline_p=1.0` for
+  `negative_result_handler` on the writing track (always blocked). Soft-skip
+  unless real baseline stats are present in writing/refinement payloads;
+  keep fail-closed for manuscript/reference/data_source import failures.
+- **Deprecated CLI modes**: `research_framework/pipeline.py` accepts
+  `data|analysis|draft|lit-review|novelty-check|regression` again as aliases
+  that print an actionable redirect and exit 2 (DeprecationWarning; no silent
+  reimplementation). Makefile `validate-novelty` and lit-review docs updated.
 - **Dual-track docs**: clarified writing (`agent_pipeline`) vs empirical demo
   (`research_framework/pipeline.py`) vs production empirics (`enhanced_pipeline` /
   `modern_did`) in `ARCHITECTURE.md` §0, `AGENTS.md`, `api_reference.md`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **TokenBucketRateLimiter per-server collisions**: replaced `hash()`-slot
+  buckets with exact per-server dict keys so `rate_limit_per_server` no longer
+  flakes under PYTHONHASHSEED / xdist (CI `test_per_server_rate_limit`).
 - **Writing pre-gate compat**: stop inventing `baseline_p=1.0` for
   `negative_result_handler` on the writing track (always blocked). Soft-skip
   unless real baseline stats are present in writing/refinement payloads;

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@
 
 .PHONY: help setup install test run clean health check lint format docs demo
 
+# Optional topic for novelty / pipeline targets
+TOPIC ?= carbon trading green innovation
+
 # Default target
 help:
 	@echo "论文-研报工作流 - FinResearch Agent"
@@ -94,7 +97,7 @@ validate-econometrics:
 	python scripts/validate_econometrics.py --method all
 
 validate-novelty:
-	python scripts/research_framework/pipeline.py --mode novelty-check
+	python scripts/agent_pipeline.py --topic "$(TOPIC)" --novelty-check
 
 # ─── Cleanup ───────────────────────────────────────────────────────────────────
 

--- a/USAGE_GUIDE.md
+++ b/USAGE_GUIDE.md
@@ -16,9 +16,10 @@ python scripts/agent_pipeline.py --topic "研究主题"
 # 演示研报（无需配置）
 python scripts/demo_research_report.py --stock 000001.SZ
 
-# 分步骤执行
-python scripts/research_framework/pipeline.py --mode lit-review --topic "..."
-python scripts/research_framework/pipeline.py --mode regression --topic "..."
+# 分步骤执行（双轨）
+python scripts/literature_download.py "..." --source arxiv,semantic,openalex
+python -m scripts.research_framework.enhanced_pipeline --topic "..."
+python scripts/agent_pipeline.py --topic "..." --use-hitl
 
 # 数据预检查
 python scripts/data_source_checker.py

--- a/scripts/SCRIPTS_INDEX.md
+++ b/scripts/SCRIPTS_INDEX.md
@@ -13,9 +13,9 @@
 | 📦 Core Modules (`scripts/core/`) | 105 | 核心库（被其他模块导入）|
 | 📊 Research Framework (`scripts/research_framework/`) | 59 | 计量方法模块 |
 | 🧭 Research Directions (`scripts/research_directions/`) | 15 | 研究方向领域 |
-| 🧪 Tests (`tests/`) | 672 | 测试文件 |
+| 🧪 Tests (`tests/`) | 674 | 测试文件 |
 | 🔌 MCP Servers (`mcp_servers/user_*/`) | 43 | MCP 数据源 |
-| **合计（仅 Python 文件）** | **956** | 不含 MCP / docs / tests fixtures |
+| **合计（仅 Python 文件）** | **958** | 不含 MCP / docs / tests fixtures |
 
 > 自动生成于 2026-08-05
 ---

--- a/scripts/agent_pipeline.py
+++ b/scripts/agent_pipeline.py
@@ -1449,6 +1449,38 @@ class AgentPipeline:
 
     # ── W1-W4 Writing Pre-Gate ──────────────────────────────────────────────
     @staticmethod
+    def _extract_baseline_for_pre_gate(result: "AgentPipelineResult") -> dict | None:
+        """Pull real DID/OLS baseline stats if the writing payload carries them.
+
+        Returns ``{"p": float, "coef": float, "did_type": str}`` or ``None``
+        when the writing track has no empirics (common — do not invent p=1.0).
+        """
+        candidates: list[Any] = []
+        for blob in (result.writing, result.refinement, result.outline):
+            if isinstance(blob, dict):
+                candidates.append(blob)
+                for key in ("regressions", "baseline", "main_result", "did"):
+                    nested = blob.get(key)
+                    if isinstance(nested, dict):
+                        candidates.append(nested)
+                    elif isinstance(nested, list) and nested and isinstance(nested[0], dict):
+                        candidates.append(nested[0])
+        for src in candidates:
+            p = src.get("p") or src.get("pvalue") or src.get("p_value") or src.get("baseline_p")
+            coef = src.get("coef") or src.get("coefficient") or src.get("baseline_coef")
+            if p is None or coef is None:
+                continue
+            try:
+                return {
+                    "p": float(p),
+                    "coef": float(coef),
+                    "did_type": src.get("did_type") or src.get("estimator") or "twfe",
+                }
+            except (TypeError, ValueError):
+                continue
+        return None
+
+    @staticmethod
     def _as_gate_report(obj: Any, *, fail_closed_on_skip: bool = True) -> dict:
         """Normalize gate return values to ``{passed, summary_message}`` dicts."""
         if isinstance(obj, dict):
@@ -1510,12 +1542,27 @@ class AgentPipeline:
             }
 
         try:
-            from scripts.research_framework.negative_result_handler import assess_result
-            # Only meaningful when manuscript exists; skip soft if manuscript already failed.
-            if reports.get("manuscript_quality", {}).get("passed"):
+            # Negative-result gate needs *real* empirics. Writing track often has
+            # none — do not hardcode baseline_p=1.0 (that always blocks).
+            baseline = self._extract_baseline_for_pre_gate(result)
+            if baseline is None:
+                reports["negative_result_handler"] = {
+                    "summary_message": (
+                        "[negative_result_handler] skipped: no baseline "
+                        "regression stats on writing track (compat soft-pass)"
+                    ),
+                    "passed": True,
+                    "skipped": True,
+                }
+            elif reports.get("manuscript_quality", {}).get("passed"):
+                from scripts.research_framework.negative_result_handler import (
+                    assess_result,
+                )
                 reports["negative_result_handler"] = self._as_gate_report(
                     assess_result(
-                        baseline_p=1.0, baseline_coef=0.0, did_type="twfe"
+                        baseline_p=float(baseline["p"]),
+                        baseline_coef=float(baseline["coef"]),
+                        did_type=str(baseline.get("did_type") or "twfe"),
                     )
                 )
         except Exception as exc:

--- a/scripts/core/tool_middleware.py
+++ b/scripts/core/tool_middleware.py
@@ -96,8 +96,8 @@ class TokenBucketRateLimiter:
     window : float
         Time window in seconds. Default 60.
     num_buckets : int
-        Number of individual server buckets + 1 global bucket.
-        bucket[0] = global; bucket[i] = server i-1. Default 32.
+        Deprecated (kept for call-site compat). Buckets are now a dict keyed by
+        server name so per-server limits never collide via ``hash()``.
     """
 
     def __init__(
@@ -108,23 +108,21 @@ class TokenBucketRateLimiter:
     ):
         self.rate = rate
         self.window = window
-        self._num_buckets = num_buckets
-        # tokens[bucket_idx] = (available_tokens, last_refill_ts)
-        self._tokens: list[tuple[float, float]] = [
-            (float(rate), time.time()) for _ in range(num_buckets)
-        ]
+        self._num_buckets = num_buckets  # retained for introspection/compat
+        # key None = global bucket; str = per-server bucket
+        self._tokens: dict[str | None, tuple[float, float]] = {
+            None: (float(rate), time.time()),
+        }
         self._lock = threading.RLock()
 
-    def _bucket_idx(self, key: str | None) -> int:
-        """Map a key (server name) to a bucket index. None = global bucket 0."""
-        if key is None:
-            return 0
-        # Simple hash to distribute server names across bucket slots
-        return (hash(key) % (self._num_buckets - 1)) + 1
+    def _bucket_key(self, key: str | None) -> str | None:
+        """Normalize limiter key. None = global; str = exact per-server bucket."""
+        return None if key is None else str(key)
 
-    def _refill(self, idx: int) -> tuple[float, float]:
+    def _refill(self, key: str | None) -> tuple[float, float]:
         """Refill tokens for a bucket based on elapsed time. Returns (tokens, now)."""
-        tokens, last_refill = self._tokens[idx]
+        bkey = self._bucket_key(key)
+        tokens, last_refill = self._tokens.get(bkey, (float(self.rate), time.time()))
         now = time.time()
         elapsed = now - last_refill
         refill_per_sec = self.rate / self.window
@@ -146,8 +144,8 @@ class TokenBucketRateLimiter:
             Whether the call is allowed, how long to wait if not, and remaining tokens.
         """
         with self._lock:
-            idx = self._bucket_idx(key)
-            tokens, last_refill = self._tokens[idx]
+            bkey = self._bucket_key(key)
+            tokens, last_refill = self._tokens.get(bkey, (float(self.rate), time.time()))
             now = time.time()
             elapsed = now - last_refill
 
@@ -157,7 +155,7 @@ class TokenBucketRateLimiter:
 
             if tokens >= 1.0:
                 tokens -= 1.0
-                self._tokens[idx] = (tokens, now)
+                self._tokens[bkey] = (tokens, now)
                 # Estimate when bucket is refilled to full
                 deficit = self.rate - tokens
                 reset_at = now + (deficit / refill_per_sec) if deficit > 0 else now
@@ -170,7 +168,7 @@ class TokenBucketRateLimiter:
             else:
                 # How long until next token?
                 wait = (1.0 - tokens) / refill_per_sec
-                self._tokens[idx] = (tokens, now)
+                self._tokens[bkey] = (tokens, now)
                 reset_at = now + wait * self.rate
                 return RateLimitResult(
                     allowed=False,

--- a/scripts/research_framework/pipeline.py
+++ b/scripts/research_framework/pipeline.py
@@ -308,16 +308,50 @@ def did_to_latex(results_list, y_labels, x_vars, title="", label=""):
 # ─────────────────────────────────────────
 # MAIN PIPELINE
 # ─────────────────────────────────────────
+
+# Deprecated aliases kept for CLI compatibility (actionable redirect, no silent reimpl).
+_DEPRECATED_MODE_REDIRECTS: dict[str, str] = {
+    "data": (
+        "Deprecated --mode data. Use: python scripts/universal_data_fetcher.py "
+        "(or MCP / local data/). Empirics: python -m scripts.research_framework.enhanced_pipeline"
+    ),
+    "analysis": (
+        "Deprecated --mode analysis. Use: "
+        "python -m scripts.research_framework.enhanced_pipeline --topic \"...\" "
+        "or import scripts.research_framework.modern_did"
+    ),
+    "draft": (
+        "Deprecated --mode draft. Writing track: "
+        "python scripts/agent_pipeline.py --topic \"...\" --use-hitl"
+    ),
+    "lit-review": (
+        "Deprecated --mode lit-review. Use: "
+        "python scripts/literature_download.py \"QUERY\" --source arxiv,semantic,openalex"
+    ),
+    "novelty-check": (
+        "Deprecated --mode novelty-check on pipeline.py. Use: "
+        "python scripts/agent_pipeline.py --topic \"...\" --novelty-check"
+    ),
+    "regression": (
+        "Deprecated --mode regression. Use: "
+        "python -m scripts.research_framework.enhanced_pipeline "
+        "or import scripts.research_framework.modern_did"
+    ),
+}
+
+
 def _parse_args() -> argparse.Namespace:
     """Parse command-line arguments."""
     ap = argparse.ArgumentParser(description="Academic paper generation pipeline")
     ap.add_argument(
         "--mode", default="full",
-        choices=["full", "design", "review"],
+        choices=["full", "design", "review", *_DEPRECATED_MODE_REDIRECTS.keys()],
         help=(
             "CLI mode. 'full' = demo TWFE pipeline (default). "
             "'design' = template REFINED_DESIGN.md scaffold. "
             "'review' = adversarial review of an existing draft (needs --draft-file). "
+            "Deprecated aliases (data/analysis/draft/lit-review/novelty-check/regression) "
+            "print a redirect and exit 2. "
             "For real empirics use enhanced_pipeline / modern_did; "
             "for writing use scripts/agent_pipeline.py."
         ),
@@ -796,9 +830,12 @@ def _main_dispatch() -> int:
     - `--mode full` (default) → call `_run_full_pipeline(args)`
     - `--mode design`        → call `_run_design_mode(args)`
     - `--mode review`        → call `_run_review_mode(args)`
+    - deprecated aliases     → stderr redirect + exit 2 (compat, no silent reimpl)
     - `--list-methods`       → print orphan-engine inventory and exit
     - Any other value        → print actionable error and return 1
     """
+    import warnings
+
     args = _parse_args()
     if args.list_methods:
         # Print inventory of orphan engines wired into RobustnessRunner.
@@ -817,6 +854,11 @@ def _main_dispatch() -> int:
             print(f"  - {m}")
         print()
         return 0
+    if args.mode in _DEPRECATED_MODE_REDIRECTS:
+        msg = _DEPRECATED_MODE_REDIRECTS[args.mode]
+        warnings.warn(msg, DeprecationWarning, stacklevel=2)
+        print(f"ERROR: {msg}", file=sys.stderr)
+        return 2
     if args.mode == "full":
         return _run_full_pipeline(args)
     if args.mode == "design":
@@ -826,7 +868,8 @@ def _main_dispatch() -> int:
     # Unknown mode: actionable error.
     print(
         f"ERROR: --mode {args.mode!r} is not recognized. "
-        "Valid modes are: full (default), design, review.",
+        "Valid modes are: full (default), design, review. "
+        f"Deprecated aliases: {', '.join(sorted(_DEPRECATED_MODE_REDIRECTS))}.",
         file=sys.stderr,
     )
     return 1

--- a/tests/test_check_data_sources_adapter.py
+++ b/tests/test_check_data_sources_adapter.py
@@ -1,0 +1,44 @@
+"""Unit tests for scripts.data_source_checker.check_data_sources adapter."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from scripts.data_source_checker import (
+    DataSourceGateReport,
+    _infer_requirements_from_text,
+    check_data_sources,
+)
+
+
+def test_infer_macro_and_customs():
+    reqs = _infer_requirements_from_text("使用海关出口与 GDP/CPI 宏观数据")
+    names = {r.name for r in reqs}
+    assert "customs" in names
+    assert "macro" in names
+
+
+def test_infer_us_equity():
+    reqs = _infer_requirements_from_text("We use yfinance and SEC 10-K filings")
+    assert any(r.name == "us_equity" for r in reqs)
+
+
+def test_check_data_sources_report_property_back_compat():
+    report = check_data_sources("纯理论")
+    assert isinstance(report, DataSourceGateReport)
+    assert report._report is report
+    assert report.passed is True
+
+
+def test_check_data_sources_available_sources_pass():
+    with patch("scripts.data_source_checker.DataSourceChecker") as MockChecker:
+        inst = MockChecker.return_value
+        result = MagicMock()
+        result.requires_synthetic_data = False
+        result.summary_message = "ok"
+        result.available_sources = ["akshare"]
+        result.unavailable_sources = []
+        inst.run.return_value = result
+        report = check_data_sources("A股上市公司财务数据")
+    assert report.passed is True
+    assert report.details["available_sources"] == ["akshare"]

--- a/tests/test_novelty_gate_search.py
+++ b/tests/test_novelty_gate_search.py
@@ -88,3 +88,70 @@ def test_evaluate_includes_search_backend_and_overlaps():
     assert result.passed is True
     assert result.details["search_backend"] == "literature_download"
     assert result.details["results"][0]["overlaps"][0]["title"] == "T"
+
+
+def test_check_novelty_back_compat_delegates():
+    g = NoveltyGate()
+    with patch.object(
+        NoveltyGate,
+        "_assess_idea",
+        return_value={"similarity": 0.55, "search_status": "ok", "overlaps": []},
+    ):
+        assert g._check_novelty("idea") == 0.55
+
+
+def test_normalize_paper_strips_doi_prefix():
+    g = NoveltyGate()
+    p = g._normalize_paper(
+        {
+            "title": "X",
+            "year": 2023,
+            "venue": "Journal of Finance",
+            "doi": "https://doi.org/10.1/abc",
+            "abstract": "hello",
+        },
+        source="openalex",
+    )
+    assert p["doi"] == "10.1/abc"
+    assert g._is_top_journal(p["venue"]) is True
+
+
+def test_top_journal_soft_boost():
+    g = NoveltyGate(lookback_years=5)
+    paper = _paper(
+        "Trading policy study",
+        year=2024,
+        venue="Journal of Finance",
+        abstract="trading policy firm outcomes",
+    )
+    with patch(
+        "scripts.literature_download.search_semantic",
+        return_value=[paper],
+    ), patch(
+        "scripts.literature_download.search_openalex",
+        return_value=[],
+    ):
+        boosted = g._assess_idea("trading policy firm outcomes")
+        paper2 = dict(paper)
+        paper2["venue"] = "Obscure Local Review"
+        with patch(
+            "scripts.literature_download.search_semantic",
+            return_value=[paper2],
+        ):
+            plain = g._assess_idea("trading policy firm outcomes")
+    assert boosted["similarity"] >= plain["similarity"]
+
+
+def test_evaluate_notes_when_all_search_unavailable():
+    g = NoveltyGate()
+    with patch.object(
+        NoveltyGate,
+        "_assess_idea",
+        return_value={
+            "similarity": 0.2,
+            "search_status": "unavailable",
+            "overlaps": [],
+        },
+    ):
+        result = g.evaluate({"ideas": ["a", "b"]})
+    assert any("文献检索不可用" in i for i in result.issues)

--- a/tests/test_pipeline_deprecated_modes_compat.py
+++ b/tests/test_pipeline_deprecated_modes_compat.py
@@ -1,0 +1,59 @@
+"""CLI soft-compat for deprecated research_framework.pipeline --mode aliases."""
+
+from __future__ import annotations
+
+import warnings
+from unittest.mock import patch
+
+import pytest
+
+from scripts.research_framework import pipeline as rf_pipeline
+
+
+@pytest.mark.parametrize(
+    "mode",
+    ["data", "analysis", "draft", "lit-review", "novelty-check", "regression"],
+)
+def test_deprecated_modes_exit_2_with_redirect(mode, capsys):
+    with patch.object(
+        rf_pipeline,
+        "_parse_args",
+        return_value=type("A", (), {
+            "mode": mode,
+            "list_methods": False,
+            "topic": "t",
+            "draft_file": None,
+        })(),
+    ):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            rc = rf_pipeline._main_dispatch()
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "Deprecated" in err or "Use:" in err
+    assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+
+
+def test_valid_design_mode_still_dispatches():
+    with patch.object(
+        rf_pipeline,
+        "_parse_args",
+        return_value=type("A", (), {
+            "mode": "design",
+            "list_methods": False,
+            "topic": "t",
+            "draft_file": None,
+            "venue": "经济研究",
+            "language": "zh",
+            "output": "papers/tmp",
+            "refined_design": None,
+        })(),
+    ), patch.object(rf_pipeline, "_run_design_mode", return_value=0) as design:
+        rc = rf_pipeline._main_dispatch()
+    assert rc == 0
+    design.assert_called_once()
+
+
+def test_deprecated_mode_keys_documented_in_choices():
+    keys = set(rf_pipeline._DEPRECATED_MODE_REDIRECTS)
+    assert {"data", "analysis", "draft", "lit-review", "novelty-check", "regression"} <= keys

--- a/tests/test_tool_middleware_unit.py
+++ b/tests/test_tool_middleware_unit.py
@@ -134,54 +134,50 @@ class TestTokenBucketRateLimiterInit:
 
     def test_tokens_initialized_to_full(self):
         r = TokenBucketRateLimiter(rate=5)
-        for tokens, _ in r._tokens:
-            assert tokens == 5.0
+        # Dict buckets: global starts full; per-server buckets are created lazily.
+        assert r._tokens[None][0] == 5.0
 
 
-class TestTokenBucketRateLimiterBucketIdx:
-    def test_none_returns_zero(self):
+class TestTokenBucketRateLimiterBucketKey:
+    def test_none_is_global(self):
         r = TokenBucketRateLimiter()
-        assert r._bucket_idx(None) == 0
+        assert r._bucket_key(None) is None
 
-    def test_same_key_same_idx(self):
+    def test_same_key_stable(self):
         r = TokenBucketRateLimiter()
-        idx1 = r._bucket_idx("user-yfinance")
-        idx2 = r._bucket_idx("user-yfinance")
-        assert idx1 == idx2
-        assert idx1 != 0  # global bucket
+        assert r._bucket_key("user-yfinance") == r._bucket_key("user-yfinance")
+        assert r._bucket_key("user-yfinance") == "user-yfinance"
 
-    def test_different_keys_different_idx(self):
+    def test_different_keys_are_distinct(self):
         r = TokenBucketRateLimiter()
-        idxs = {r._bucket_idx(f"server_{i}") for i in range(20)}
-        # Should spread across 31 buckets (1 global + 31 server)
-        assert len(idxs) > 1
+        keys = {r._bucket_key(f"server_{i}") for i in range(20)}
+        assert len(keys) == 20  # exact per-server keys, no hash collisions
 
-    def test_bucket_idx_within_range(self):
+    def test_bucket_key_is_server_name(self):
         r = TokenBucketRateLimiter(num_buckets=8)
         for key in ["a", "b", "c", "d", "e", "f"]:
-            idx = r._bucket_idx(key)
-            assert 1 <= idx <= 7
+            assert r._bucket_key(key) == key
 
 
 class TestTokenBucketRateLimiterRefill:
     def test_refill_full_bucket(self):
         r = TokenBucketRateLimiter(rate=10, window=60.0)
-        r._tokens[5] = (10.0, time.time() - 60.0)  # full, 60s ago
-        tokens, now = r._refill(5)
+        r._tokens["srv"] = (10.0, time.time() - 60.0)  # full, 60s ago
+        tokens, now = r._refill("srv")
         assert tokens == 10.0
 
     def test_refill_partial_bucket(self):
         r = TokenBucketRateLimiter(rate=10, window=10.0)
         # 5 tokens, 5s ago, refill rate = 10/10 = 1/s
-        r._tokens[3] = (5.0, time.time() - 5.0)
-        tokens, _ = r._refill(3)
+        r._tokens["srv"] = (5.0, time.time() - 5.0)
+        tokens, _ = r._refill("srv")
         # tokens + elapsed * refill_rate = 5 + 5 * 1 = 10
         assert tokens == 10.0
 
     def test_refill_caps_at_rate(self):
         r = TokenBucketRateLimiter(rate=5, window=1.0)
-        r._tokens[2] = (5.0, time.time() - 100.0)  # old, would overfill
-        tokens, _ = r._refill(2)
+        r._tokens["srv"] = (5.0, time.time() - 100.0)  # old, would overfill
+        tokens, _ = r._refill("srv")
         assert tokens == 5.0  # capped at rate
 
 
@@ -216,17 +212,9 @@ class TestTokenBucketRateLimiterCheck:
         assert result.allowed is False
 
     def test_per_server_buckets_independent(self):
-        r = TokenBucketRateLimiter(rate=1, window=60.0, num_buckets=64)
-        # With 64 buckets the probability of a hash collision between two
-        # arbitrary keys is tiny; use many tries to guarantee separation.
-        for _ in range(20):
-            key_a = f"server_a_{_}_"
-            key_b = f"server_b_{_}_"
-            idx_a = r._bucket_idx(key_a)
-            idx_b = r._bucket_idx(key_b)
-            if idx_a != idx_b and idx_a != 0 and idx_b != 0:
-                break
-        # Consume token in bucket A, B should still have a token
+        r = TokenBucketRateLimiter(rate=1, window=60.0)
+        # Exact per-server dict keys — no hash-slot collisions.
+        key_a, key_b = "server_a", "server_b"
         r.check(key_a)
         result = r.check(key_b)
         assert result.allowed is True

--- a/tests/test_writing_pre_gate_datasource.py
+++ b/tests/test_writing_pre_gate_datasource.py
@@ -77,6 +77,77 @@ def test_writing_pre_gate_fail_closed_on_import_error():
     assert any("data_source_checker" in e for e in result.errors)
 
 
+def test_extract_baseline_from_writing_payload():
+    cfg = AgentPipelineConfig(topic="t")
+    result = AgentPipelineResult(
+        config=cfg,
+        writing={"baseline": {"p": 0.03, "coef": 0.12, "did_type": "cs"}},
+    )
+    base = AgentPipeline._extract_baseline_for_pre_gate(result)
+    assert base == {"p": 0.03, "coef": 0.12, "did_type": "cs"}
+    assert AgentPipeline._extract_baseline_for_pre_gate(
+        AgentPipelineResult(config=cfg, writing={"body": "no stats"})
+    ) is None
+
+
+def test_writing_pre_gate_soft_skips_negative_result_without_baseline():
+    """Compat: writing track without empirics must not hard-block on fake p=1.0."""
+    cfg = AgentPipelineConfig(topic="t")
+    pipeline = AgentPipeline(cfg)
+    result = AgentPipelineResult(config=cfg, success=True)
+
+    with patch(
+        "scripts.research_framework.manuscript_quality_gate.check_manuscript",
+        return_value=DataSourceGateReport(passed=True, summary_message="mq"),
+    ), patch(
+        "scripts.research_framework.reference_validator.validate_references",
+        return_value=DataSourceGateReport(passed=True, summary_message="ref"),
+    ), patch(
+        "scripts.data_source_checker.check_data_sources",
+        return_value=DataSourceGateReport(passed=True, summary_message="ds"),
+    ):
+        pipeline._run_writing_pre_gate(result, "理论综述，无回归结果。")
+
+    nr = result.quality_reports["writing_pre_gate/negative_result_handler"]
+    assert nr["passed"] is True
+    assert nr.get("skipped") is True
+    assert result.quality_reports["writing_pre_gate"]["passed"] is True
+
+
+def test_writing_pre_gate_runs_negative_result_when_baseline_present():
+    cfg = AgentPipelineConfig(topic="t")
+    pipeline = AgentPipeline(cfg)
+    result = AgentPipelineResult(
+        config=cfg,
+        success=True,
+        writing={"p": 0.2, "coef": 0.01, "did_type": "twfe"},
+    )
+    called = {}
+
+    def _assess(**kwargs):
+        called.update(kwargs)
+        return DataSourceGateReport(passed=True, summary_message="nr ok")
+
+    with patch(
+        "scripts.research_framework.manuscript_quality_gate.check_manuscript",
+        return_value=DataSourceGateReport(passed=True, summary_message="mq"),
+    ), patch(
+        "scripts.research_framework.reference_validator.validate_references",
+        return_value=DataSourceGateReport(passed=True, summary_message="ref"),
+    ), patch(
+        "scripts.data_source_checker.check_data_sources",
+        return_value=DataSourceGateReport(passed=True, summary_message="ds"),
+    ), patch(
+        "scripts.research_framework.negative_result_handler.assess_result",
+        side_effect=_assess,
+    ):
+        pipeline._run_writing_pre_gate(result, "含回归结果的草稿")
+
+    assert called.get("baseline_p") == 0.2
+    assert called.get("baseline_coef") == 0.01
+    assert result.quality_reports["writing_pre_gate"]["passed"] is True
+
+
 def test_writing_pre_gate_uses_correct_import_path():
     """Regression: must import scripts.data_source_checker, not research_framework.*."""
     cfg = AgentPipelineConfig(topic="t")

--- a/使用指南.md
+++ b/使用指南.md
@@ -226,7 +226,7 @@ python scripts/agent_pipeline.py --topic "碳排放权交易对企业绿色创�
 python scripts/demo_research_report.py --stock 000001.SZ
 
 # 分步骤执行
-python scripts/research_framework/pipeline.py --mode lit-review --topic "数字金融"
+python scripts/literature_download.py "数字金融" --source arxiv,semantic,openalex
 ```
 
 ---
@@ -937,8 +937,8 @@ python scripts/idea_data_checker.py           # 想法-数据交叉验证
 
 # === 研究流水线 ===
 python scripts/agent_pipeline.py --topic "研究主题"
-python scripts/research_framework/pipeline.py --mode lit-review --topic "..."
-python scripts/research_framework/pipeline.py --mode regression --topic "..."
+python scripts/literature_download.py "..." --source arxiv,semantic,openalex
+python -m scripts.research_framework.enhanced_pipeline --topic "..."
 
 # === 研报 ===
 python scripts/demo_research_report.py --stock 000001.SZ
@@ -1000,8 +1000,8 @@ pip install -e ".[extras]"
 可以。每个 Skill 都是独立的：
 
 ```bash
-python scripts/research_framework/pipeline.py --mode lit-review --topic "..."
-python scripts/research_framework/pipeline.py --mode regression --topic "..."
+python scripts/literature_download.py "..." --source arxiv,semantic,openalex
+python -m scripts.research_framework.enhanced_pipeline --topic "..."
 ```
 
 ### Q5: LaTeX 编译失败怎么办？


### PR DESCRIPTION
## Summary
- **Compat**: `pipeline.py` again accepts deprecated modes (`data|analysis|draft|lit-review|novelty-check|regression`) but prints actionable redirects + `DeprecationWarning` and exits `2` (no silent reimplementation).
- **Compat**: writing pre-gate no longer invents `baseline_p=1.0` (always blocked); soft-skips `negative_result_handler` unless real baseline stats exist in writing/refinement payloads. Manuscript/reference/data_source stay fail-closed.
- **CI rate**: new tests for deprecated modes, baseline extract/soft-skip, NoveltyGate back-compat/boost/unavailable path, `check_data_sources` adapter; docs/Makefile/使用指南 sync; SCRIPTS_INDEX count 674.

## Test plan
- [x] `pytest tests/test_pipeline_deprecated_modes_compat.py tests/test_writing_pre_gate_datasource.py tests/test_novelty_gate_search.py tests/test_check_data_sources_adapter.py tests/test_scripts_index_consistency.py tests/test_pipeline_dispatch_p0_audit.py -q`
- [ ] CI green on PR


Made with [Cursor](https://cursor.com)