### PR TITLE
fix: empirical data root + TOPIC integrity for isolation hosts

### DIFF
--- a/.cursor/rules/agent-host-isolation.mdc
+++ b/.cursor/rules/agent-host-isolation.mdc
@@ -1,0 +1,20 @@
+---
+description: Isolation / autopilot host protocol (overrides greet-HITL when FINAI_AUTOPILOT)
+globs:
+alwaysApply: false
+---
+
+# Agent-host isolation (when user says 不需要确认 / FINAI_NO_HITL / 交 FINAL)
+
+When the user (or slot) requires **no questions, no wait, no Mock**:
+
+1. Prefer `python scripts/agent_host_entry.py` — do **not** freestyle `run_real_*.py`.
+2. Set / respect `FINAI_EMPIRICAL_DATA_ROOT` (default candidates include `/data/实证分析`).
+   Check local panels **before** remote fetch or proxy substitution.
+3. Never substitute: city patents → firm green patents; overseas revenue → customs HS;
+   interest coverage → bond spreads. Record hard-gaps in `SKIPPED_CONFIG.md`.
+4. Delivery must include `FINAL.md` + `SKIPPED_CONFIG.md` (not only `CODEX_FINAL.md` / PDF).
+5. Writing success with empirics gaps = `partial`, not journal-ready causal completion.
+6. Do not start MCP servers unless the user asked; do not invent coefficients.
+
+Interactive research chats (no autopilot) still follow `system-init.mdc` greet + HITL.

--- a/.env.example
+++ b/.env.example
@@ -78,3 +78,12 @@ OLLAMA_SANITIZE_DATA=true
 # allow    — 直接放行，自动化脚本
 # disabled — 完全禁用，正式生产环境
 MCP_MOCK_MODE=confirm
+
+# ── 实证 / 隔离主机 ───────────────────────────────────────────────────────────
+# 共享实证面板根目录（Layer 0，优先于 MCP/CLI）。隔离槽务必设置。
+# 例：FINAI_EMPIRICAL_DATA_ROOT=/data/实证分析
+FINAI_EMPIRICAL_DATA_ROOT=
+# agent_host_entry 默认会设为 1；FINAL.md 使用 autopilot 下一步提示
+FINAI_AUTOPILOT=
+# 批处理关闭 HITL（agent_host_entry 默认已关闭）
+# FINAI_NO_HITL=1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,17 @@ When a host agent is told **not to ask**, **not to wait**, and **not to use Mock
 3. **Do not** freestyle a second research stack, fabricate citations/coefficients, or silently enable Mock.
 4. Empirical work (DID/IV/data fetch) remains a **separate hand-off** from the writing pipeline; see dual-track notes in `docs/ARCHITECTURE.md`.
 5. Batch HITL off: default for `agent_host_entry`; or `FINAI_NO_HITL=1` / `--no-use-hitl` on other CLIs.
+6. **Local empirics first**: set `FINAI_EMPIRICAL_DATA_ROOT` (e.g. `/data/实证分析`).
+   `DataFetcher.fetch` Layer 0 reads this root before MCP/CLI. Skipping local panels
+   and substituting city patents / overseas revenue / interest coverage for
+   firm green patents / customs HS / bond spreads is **proxy laundering** — forbidden.
+7. **TOPIC integrity**: `agent_host_entry` records hard-gaps in `SKIPPED_CONFIG.md`.
+   Writing may continue as `status=partial` with non-claims; use `--block-on-topic-gaps`
+   to refuse the whole run. Causal PDF delivery is not "completed" while gaps remain.
+8. **Delivery contract**: required artifacts are `FINAL.md` + `SKIPPED_CONFIG.md`
+   (`CODEX_FINAL.md` alone is insufficient). Optional: `--check-delivery` → `DELIVERY.md`.
+9. Interactive Cursor chats still greet / HITL per `.cursor/rules/system-init.mdc`;
+   isolation autopilot overrides that via `FINAI_AUTOPILOT=1` + `agent_host_entry` only.
 
 ---
 

--- a/scripts/SCRIPTS_INDEX.md
+++ b/scripts/SCRIPTS_INDEX.md
@@ -9,15 +9,15 @@
 
 | 分类 | 数量 | 说明 |
 |------|------|------|
-| 🚀 Entry Points (`scripts/*.py`) | 105 | 顶级入口脚本（含 CLI） |
-| 📦 Core Modules (`scripts/core/`) | 105 | 核心库（被其他模块导入）|
+| 🚀 Entry Points (`scripts/*.py`) | 106 | 顶级入口脚本（含 CLI） |
+| 📦 Core Modules (`scripts/core/`) | 109 | 核心库（被其他模块导入）|
 | 📊 Research Framework (`scripts/research_framework/`) | 59 | 计量方法模块 |
 | 🧭 Research Directions (`scripts/research_directions/`) | 15 | 研究方向领域 |
-| 🧪 Tests (`tests/`) | 674 | 测试文件 |
+| 🧪 Tests (`tests/`) | 675 | 测试文件 |
 | 🔌 MCP Servers (`mcp_servers/user_*/`) | 43 | MCP 数据源 |
-| **合计（仅 Python 文件）** | **958** | 不含 MCP / docs / tests fixtures |
+| **合计（仅 Python 文件）** | **964** | 不含 MCP / docs / tests fixtures |
 
-> 自动生成于 2026-08-05
+> 自动生成于 2026-08-08
 ---
 
 ## 一、Entry Points · 用户入口
@@ -218,4 +218,4 @@ report_*.py           # 报告生成（小写下划线）
 
 ---
 
-*本索引由 `scripts/SCRIPTS_INDEX.md` 维护，最后更新: 2026-08-05（自动对账）
+*本索引由 `scripts/SCRIPTS_INDEX.md` 维护，最后更新: 2026-08-08（自动对账）

--- a/scripts/agent_host_entry.py
+++ b/scripts/agent_host_entry.py
@@ -6,6 +6,8 @@ Use when the host agent must:
   - not use Mock for research conclusions
   - write output/SKIPPED_CONFIG.md + output/FINAL.md on blockers
   - avoid inventing a parallel pipeline outside FinAI
+  - check FINAI_EMPIRICAL_DATA_ROOT and TOPIC hard requirements before
+    claiming causal empirics
 
 Examples:
   python scripts/agent_host_entry.py
@@ -30,29 +32,119 @@ from scripts.core.agent_host_report import (  # noqa: E402
 )
 
 
-def _read_topic_md(cwd: Path) -> str:
+def _read_topic_md_full(cwd: Path) -> str:
     for name in ("TOPIC.md", "topic.md"):
         p = cwd / name
         if p.is_file():
             text = p.read_text(encoding="utf-8").strip()
             if text:
-                # First non-empty, non-heading line as short topic; keep full text in report via file
-                for line in text.splitlines():
-                    s = line.strip()
-                    if not s or s.startswith("#"):
-                        continue
-                    return s[:300]
-                return text[:300]
+                return text
     return ""
 
 
-def _resolve_topic(arg_topic: str | None, cwd: Path) -> str:
+def _short_topic(text: str) -> str:
+    if not text:
+        return ""
+    for line in text.splitlines():
+        s = line.strip()
+        if not s or s.startswith("#"):
+            continue
+        return s[:300]
+    return text[:300]
+
+
+def _resolve_topic(arg_topic: str | None, cwd: Path) -> tuple[str, str]:
+    """Return (short_topic, full_text_for_integrity)."""
     if arg_topic and arg_topic.strip():
-        return arg_topic.strip()
-    from_md = _read_topic_md(cwd)
-    if from_md:
-        return from_md
-    return ""
+        t = arg_topic.strip()
+        full = _read_topic_md_full(cwd)
+        # Prefer full TOPIC.md for integrity when present; short topic for reports
+        return t[:300], full or t
+    full = _read_topic_md_full(cwd)
+    if full:
+        return _short_topic(full), full
+    return "", ""
+
+
+def _assess_host_context(
+    topic_full: str,
+    completed: list[str],
+) -> tuple[list[SkipItem], list[str], object | None]:
+    """Empirical root + TOPIC integrity → skip items and boundaries."""
+    skipped: list[SkipItem] = []
+    boundaries: list[str] = []
+    integrity = None
+
+    try:
+        from scripts.core.empirical_data_root import resolve_empirical_data_root
+
+        root = resolve_empirical_data_root()
+        if root.available:
+            completed.append(
+                f"Empirical data root → {root.path} (source={root.source})"
+            )
+        else:
+            completed.append(
+                f"Empirical data root unavailable "
+                f"(source={root.source}, path={root.path})"
+            )
+            skipped.append(
+                SkipItem(
+                    name="FINAI_EMPIRICAL_DATA_ROOT",
+                    reason=(
+                        "Shared empirical data directory not found/readable. "
+                        "Isolation agents must check local panels before remote fetch "
+                        "or proxy substitution."
+                    ),
+                    fix_hint=(
+                        "export FINAI_EMPIRICAL_DATA_ROOT=/data/实证分析 "
+                        "(or your panel directory) before empirics."
+                    ),
+                )
+            )
+            boundaries.append(
+                "No local empirical root — do not freestyle proxy DID/IV; "
+                "writing may still proceed."
+            )
+    except Exception as exc:  # pragma: no cover
+        completed.append(f"empirical_data_root failed: {exc}")
+
+    try:
+        from scripts.core.topic_integrity import assess_topic_integrity
+
+        integrity = assess_topic_integrity(topic_full)
+        completed.append(
+            f"TOPIC integrity → requirements={integrity.requirements} "
+            f"gaps={integrity.hard_gaps} proxies={len(integrity.proxy_warnings)}"
+        )
+        for item in integrity.to_skipped_items():
+            skipped.append(
+                SkipItem(
+                    name=item["item"],
+                    reason=item["reason"],
+                    fix_hint=item.get("fix_hint", ""),
+                )
+            )
+        for w in integrity.proxy_warnings:
+            skipped.append(
+                SkipItem(
+                    name=f"proxy_warning:{w.split(':')[0]}",
+                    reason=w,
+                    fix_hint=(
+                        "Remove proxy-laundered empirics; obtain the required panel "
+                        "or narrow TOPIC."
+                    ),
+                )
+            )
+        if integrity.hard_gaps:
+            boundaries.append(
+                "TOPIC hard-gaps present — writing OK with explicit non-claims; "
+                "causal empirics / journal-ready causal PDF forbidden until gaps close."
+            )
+    except Exception as exc:  # pragma: no cover
+        completed.append(f"topic_integrity failed: {exc}")
+
+    return skipped, boundaries, integrity
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -86,10 +178,27 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Only run health/preflight and write skip/final reports; do not start writing pipeline",
     )
+    parser.add_argument(
+        "--block-on-topic-gaps",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help=(
+            "If TOPIC hard empirics requirements lack local panels, block the whole run "
+            "(default: record skips, allow writing with non-claims)"
+        ),
+    )
+    parser.add_argument(
+        "--check-delivery",
+        action="store_true",
+        help="After run (or alone with --dry-run-preflight), validate delivery contract",
+    )
     args = parser.parse_args(argv)
 
+    # Isolation default: autopilot wording in FINAL.md
+    os.environ.setdefault("FINAI_AUTOPILOT", "1")
+
     cwd = Path.cwd()
-    topic = _resolve_topic(args.topic or None, cwd)
+    topic, topic_full = _resolve_topic(args.topic or None, cwd)
     output_dir = Path(args.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -113,6 +222,10 @@ def main(argv: list[str] | None = None) -> int:
         print("ERROR: missing topic (use --topic or TOPIC.md)", file=sys.stderr)
         print(f"Wrote {output_dir / 'SKIPPED_CONFIG.md'} and {output_dir / 'FINAL.md'}")
         return 2
+
+    context_skips, context_bounds, integrity = _assess_host_context(
+        topic_full or topic, completed
+    )
 
     # Health / LLM preflight (no MCP server start)
     llm_available = False
@@ -138,31 +251,57 @@ def main(argv: list[str] | None = None) -> int:
         allow_mock=allow_mock,
     )
 
+    hard_empirics_gaps = bool(
+        integrity and getattr(integrity, "hard_gaps", None)
+    )
+    if args.block_on_topic_gaps and hard_empirics_gaps:
+        for s in context_skips:
+            if s.name.startswith("empirics:") or s.name.startswith("proxy_warning:"):
+                skipped.append(s)
+
     if skipped or args.dry_run_preflight:
         # dry-run with healthy LLM still writes a progress FINAL (not blocked)
         if args.dry_run_preflight and not skipped:
             from scripts.core.agent_host_report import HostRunReport, write_host_reports
 
+            # Still surface non-blocking context skips (data root / soft gaps)
+            soft = [
+                s
+                for s in context_skips
+                if not s.name.startswith("LLM")
+            ]
             write_host_reports(
                 HostRunReport(
                     topic=topic,
                     output_dir=output_dir,
                     status="partial",
-                    skipped=[],
+                    skipped=soft,
                     completed_steps=completed + ["dry-run-preflight: pipeline not started"],
-                    boundaries=[
+                    boundaries=context_bounds
+                    + [
                         "Preflight only; writing/empirical pipeline not executed.",
                     ],
                     exit_code=0,
                 )
             )
+            if args.check_delivery:
+                from scripts.core.delivery_contract import validate_delivery
+
+                rep = validate_delivery(output_dir)
+                (output_dir / "DELIVERY.md").write_text(rep.to_markdown(), encoding="utf-8")
             print(f"Preflight OK. Reports in {output_dir}")
             return 0
 
+        merged = list(skipped)
+        seen = {s.name for s in merged}
+        for s in context_skips:
+            if s.name not in seen:
+                merged.append(s)
+                seen.add(s.name)
         write_blocked_run(
             topic=topic,
             output_dir=output_dir,
-            skipped=skipped
+            skipped=merged
             or [
                 SkipItem(
                     name="dry-run",
@@ -173,6 +312,11 @@ def main(argv: list[str] | None = None) -> int:
             completed_steps=completed,
             exit_code=4 if skipped else 0,
         )
+        if args.check_delivery:
+            from scripts.core.delivery_contract import validate_delivery
+
+            rep = validate_delivery(output_dir)
+            (output_dir / "DELIVERY.md").write_text(rep.to_markdown(), encoding="utf-8")
         print(
             f"Blocked or dry-run. See {output_dir / 'SKIPPED_CONFIG.md'} "
             f"and {output_dir / 'FINAL.md'}",
@@ -210,7 +354,8 @@ def main(argv: list[str] | None = None) -> int:
                 llm_available=False,
                 llm_status="agent_pipeline refused to start without LLM",
                 allow_mock=allow_mock,
-            ),
+            )
+            + context_skips,
             completed_steps=completed + ["agent_pipeline preflight refused run"],
             exit_code=4,
         )
@@ -226,7 +371,8 @@ def main(argv: list[str] | None = None) -> int:
                     reason="; ".join(result.errors[:5]) or "pipeline returned success=False",
                     fix_hint="Inspect output/fin-manuscript and re-run with LLM configured.",
                 )
-            ],
+            ]
+            + context_skips,
             completed_steps=completed + ["agent_pipeline started but did not fully succeed"],
             exit_code=1,
         )
@@ -234,22 +380,33 @@ def main(argv: list[str] | None = None) -> int:
 
     from scripts.core.agent_host_report import HostRunReport, write_host_reports
 
+    # Writing success + empirics hard-gaps → partial (not "completed" causal paper)
+    status = "partial" if context_skips else "completed"
+    bounds = list(context_bounds) + [
+        "Writing pipeline artifacts are under output/fin-manuscript/.",
+        "Empirical DID/IV stages remain a separate hand-off "
+        "(research_framework / universal_data_fetcher + FINAI_EMPIRICAL_DATA_ROOT).",
+    ]
     write_host_reports(
         HostRunReport(
             topic=topic,
             output_dir=output_dir,
-            status="completed",
-            skipped=[],
+            status=status,
+            skipped=context_skips,
             completed_steps=completed + ["agent_pipeline finished successfully"],
-            boundaries=[
-                "Writing pipeline artifacts are under output/fin-manuscript/.",
-                "Empirical DID/IV stages remain a separate hand-off "
-                "(research_framework / universal_data_fetcher).",
-            ],
+            boundaries=bounds,
             exit_code=0,
         )
     )
-    print(f"✅ Agent-host run completed. See {output_dir / 'FINAL.md'}")
+    if args.check_delivery:
+        from scripts.core.delivery_contract import validate_delivery
+
+        rep = validate_delivery(output_dir)
+        (output_dir / "DELIVERY.md").write_text(rep.to_markdown(), encoding="utf-8")
+    print(
+        f"{'⚠️ Partial' if status == 'partial' else '✅'} Agent-host run finished. "
+        f"See {output_dir / 'FINAL.md'}"
+    )
     return 0
 
 

--- a/scripts/core/agent_host_report.py
+++ b/scripts/core/agent_host_report.py
@@ -6,6 +6,7 @@ host agents freestyle outside the official pipeline.
 """
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -106,13 +107,30 @@ def write_host_reports(report: HostRunReport) -> tuple[Path, Path]:
         f"- Skip log: `{report.skipped_path.name}`",
         f"- This report: `{report.final_path.name}`",
         "",
-        "## Next actions for the human operator",
-        "",
-        "1. Configure at least one LLM (`DEEPSEEK_API_KEY` or `RELAY_API_KEY` or Ollama).",
-        "2. Re-run: `python scripts/agent_host_entry.py --topic \"...\"`",
-        "3. Interactive path (human TTY): `python scripts/start_research.py --topic \"...\"`",
+        "## Next actions",
         "",
     ]
+    # Autopilot / isolation: do not imply chat confirmation or freestyle empirics.
+    autopilot = os.environ.get("FINAI_AUTOPILOT", "").strip() in {"1", "true", "yes"}
+    if autopilot or report.entry.endswith("agent_host_entry.py"):
+        final_lines += [
+            "1. If **blocked**: fix SKIPPED items, then re-run "
+            "`python scripts/agent_host_entry.py` — do **not** invent a parallel pipeline.",
+            "2. If **partial** with empirics hard-gaps: writing may exist; "
+            "**do not** claim causal DID/IV results or ship proxy-laundered empirics.",
+            "3. Empirics hand-off: set `FINAI_EMPIRICAL_DATA_ROOT`, place matching panels, "
+            "then use `enhanced_pipeline` / `modern_did` (not freestyle `run_real_*.py`).",
+            "4. Delivery contract requires `FINAL.md` + `SKIPPED_CONFIG.md` "
+            "(not `CODEX_FINAL.md` alone).",
+            "",
+        ]
+    else:
+        final_lines += [
+            "1. Configure at least one LLM (`DEEPSEEK_API_KEY` or `RELAY_API_KEY` or Ollama).",
+            "2. Re-run: `python scripts/agent_host_entry.py --topic \"...\"`",
+            "3. Interactive path (human TTY): `python scripts/start_research.py --topic \"...\"`",
+            "",
+        ]
 
     skipped_path = report.skipped_path
     final_path = report.final_path

--- a/scripts/core/delivery_contract.py
+++ b/scripts/core/delivery_contract.py
@@ -1,0 +1,107 @@
+"""Canonical delivery package for isolation / agent-host runs.
+
+Test agents wrote CODEX_FINAL.md, scattered figures, or only main.pdf without
+SKIPPED_CONFIG / FINAL. This module validates the contract.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+__all__ = [
+    "DeliveryReport",
+    "validate_delivery",
+    "canonical_delivery_paths",
+]
+
+_REQUIRED = ("FINAL.md", "SKIPPED_CONFIG.md")
+_OPTIONAL_PDF = ("main.pdf", "paper.pdf", "manuscript.pdf")
+
+
+@dataclass
+class DeliveryReport:
+    ok: bool
+    missing: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    found: dict[str, str] = field(default_factory=dict)
+
+    def to_markdown(self) -> str:
+        lines = ["# Delivery contract", ""]
+        lines.append(f"- status: {'OK' if self.ok else 'INCOMPLETE'}")
+        if self.found:
+            lines.append("- found:")
+            for k, v in self.found.items():
+                lines.append(f"  - {k}: `{v}`")
+        if self.missing:
+            lines.append("- missing:")
+            for m in self.missing:
+                lines.append(f"  - {m}")
+        if self.warnings:
+            lines.append("- warnings:")
+            for w in self.warnings:
+                lines.append(f"  - {w}")
+        lines.append("")
+        return "\n".join(lines)
+
+
+def canonical_delivery_paths(output_dir: Path) -> dict[str, Path]:
+    out = Path(output_dir)
+    return {
+        "FINAL.md": out / "FINAL.md",
+        "SKIPPED_CONFIG.md": out / "SKIPPED_CONFIG.md",
+        "DELIVERY.md": out / "DELIVERY.md",
+    }
+
+
+def validate_delivery(
+    output_dir: str | Path,
+    *,
+    require_pdf: bool = False,
+    allow_alias_final: bool = False,
+) -> DeliveryReport:
+    """Validate isolation delivery under output_dir."""
+    root = Path(output_dir)
+    missing: list[str] = []
+    warnings: list[str] = []
+    found: dict[str, str] = {}
+
+    for name in _REQUIRED:
+        p = root / name
+        if p.is_file() and p.stat().st_size > 0:
+            found[name] = str(p)
+        else:
+            # Common misuse: CODEX_FINAL.md instead of FINAL.md
+            alias = root / "CODEX_FINAL.md"
+            if name == "FINAL.md" and allow_alias_final and alias.is_file():
+                warnings.append(
+                    "Found CODEX_FINAL.md but contract requires FINAL.md; "
+                    "copy/rename to FINAL.md."
+                )
+                found["CODEX_FINAL.md"] = str(alias)
+                missing.append("FINAL.md")
+            else:
+                missing.append(name)
+
+    pdf_hit = None
+    for name in _OPTIONAL_PDF:
+        # search shallow + one level
+        for cand in [root / name, *root.glob(f"*/{name}"), *root.glob(f"**/{name}")]:
+            if cand.is_file() and cand.stat().st_size > 0:
+                pdf_hit = cand
+                break
+        if pdf_hit:
+            break
+    if pdf_hit:
+        found["pdf"] = str(pdf_hit)
+    elif require_pdf:
+        missing.append("main.pdf (or paper.pdf)")
+    else:
+        warnings.append("No PDF found (optional unless require_pdf=True)")
+
+    # Soft signal: figures directory empty while PDF claims charts
+    fig_dirs = [root / "figures", root / "figs", *root.glob("*/figures")]
+    if any(d.is_dir() and not any(d.iterdir()) for d in fig_dirs if d.is_dir()):
+        warnings.append("Empty figures/ directory present")
+
+    ok = not missing
+    return DeliveryReport(ok=ok, missing=missing, warnings=warnings, found=found)

--- a/scripts/core/empirical_data_root.py
+++ b/scripts/core/empirical_data_root.py
@@ -1,0 +1,116 @@
+"""Shared empirical data root (FINAI_EMPIRICAL_DATA_ROOT).
+
+Isolation agents repeatedly skipped local panels under ``/data/实证分析``
+because fetchers never consulted this env. This module is the single resolver.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+__all__ = [
+    "EmpiricalDataRoot",
+    "resolve_empirical_data_root",
+    "scan_empirical_root",
+    "find_candidate_files",
+]
+
+_DEFAULT_CANDIDATES = (
+    "/data/实证分析",
+    str(Path.home() / "data" / "实证分析"),
+    "data/实证分析",
+    "data",
+)
+
+
+@dataclass(frozen=True)
+class EmpiricalDataRoot:
+    path: Path | None
+    source: str  # env | default | missing
+    exists: bool
+    readable: bool
+
+    @property
+    def available(self) -> bool:
+        return bool(self.path and self.exists and self.readable)
+
+
+def resolve_empirical_data_root(
+    explicit: str | Path | None = None,
+    *,
+    env_var: str = "FINAI_EMPIRICAL_DATA_ROOT",
+) -> EmpiricalDataRoot:
+    """Resolve the shared empirical data directory (read-only usage)."""
+    candidates: list[tuple[str, str]] = []
+    if explicit:
+        candidates.append((str(explicit), "explicit"))
+    env_val = (os.environ.get(env_var) or "").strip()
+    if env_val:
+        candidates.append((env_val, "env"))
+    for c in _DEFAULT_CANDIDATES:
+        candidates.append((c, "default"))
+
+    seen: set[str] = set()
+    for raw, source in candidates:
+        key = os.path.abspath(os.path.expanduser(raw))
+        if key in seen:
+            continue
+        seen.add(key)
+        p = Path(key)
+        if p.is_dir():
+            readable = os.access(p, os.R_OK)
+            return EmpiricalDataRoot(path=p, source=source, exists=True, readable=readable)
+
+    # Prefer env path even if missing (so reports show the intended root)
+    if env_val:
+        p = Path(os.path.expanduser(env_val)).resolve()
+        return EmpiricalDataRoot(path=p, source="env", exists=False, readable=False)
+    return EmpiricalDataRoot(path=None, source="missing", exists=False, readable=False)
+
+
+def scan_empirical_root(
+    root: EmpiricalDataRoot | Path | None = None,
+    *,
+    max_files: int = 200,
+) -> list[Path]:
+    """List data-like files under the empirical root (csv/parquet/dta/xlsx)."""
+    if isinstance(root, EmpiricalDataRoot):
+        base = root.path if root.available else None
+    else:
+        base = Path(root) if root else resolve_empirical_data_root().path
+    if base is None or not base.is_dir():
+        return []
+    exts = {".csv", ".parquet", ".pq", ".dta", ".xlsx", ".xls", ".feather", ".pkl"}
+    out: list[Path] = []
+    try:
+        for p in base.rglob("*"):
+            if not p.is_file():
+                continue
+            if p.suffix.lower() in exts and "__pycache__" not in p.parts:
+                out.append(p)
+                if len(out) >= max_files:
+                    break
+    except OSError:
+        return []
+    return out
+
+
+def find_candidate_files(
+    keywords: list[str],
+    root: EmpiricalDataRoot | Path | None = None,
+    *,
+    limit: int = 20,
+) -> list[Path]:
+    """Find files whose path/name contains any keyword (case-insensitive)."""
+    keys = [k.lower() for k in keywords if k]
+    if not keys:
+        return []
+    hits: list[Path] = []
+    for p in scan_empirical_root(root):
+        hay = str(p).lower()
+        if any(k in hay for k in keys):
+            hits.append(p)
+            if len(hits) >= limit:
+                break
+    return hits

--- a/scripts/core/topic_integrity.py
+++ b/scripts/core/topic_integrity.py
@@ -1,0 +1,156 @@
+"""TOPIC.md integrity: detect hard data/ID requirements vs proxy laundering.
+
+Test-user runs shipped causal PDFs while substituting city patents for firm
+patents, overseas revenue for customs, interest coverage for bond spreads.
+This module flags those hard gaps so host mode can fail-closed on empirics.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+from scripts.core.empirical_data_root import (
+    EmpiricalDataRoot,
+    find_candidate_files,
+    resolve_empirical_data_root,
+)
+
+__all__ = [
+    "HardRequirement",
+    "TopicIntegrityReport",
+    "assess_topic_integrity",
+]
+
+
+@dataclass(frozen=True)
+class HardRequirement:
+    key: str
+    label: str
+    pattern: re.Pattern[str]
+    # Path keywords that suggest a local panel may cover the requirement
+    file_keywords: tuple[str, ...]
+    # Phrases that indicate the agent already used a forbidden proxy
+    proxy_patterns: tuple[re.Pattern[str], ...] = ()
+
+
+_HARD: tuple[HardRequirement, ...] = (
+    HardRequirement(
+        key="firm_green_patents",
+        label="企业级绿色专利（非城市/省份聚合）",
+        pattern=re.compile(
+            r"(企业.?级.?绿色.?专利|firm[- ]?level.*green.*patent|"
+            r"绿色专利.*企业|企业绿色专利|上市公司.*绿色专利)",
+            re.I,
+        ),
+        file_keywords=("绿色专利", "green_patent", "patent", "ipc", "绿色"),
+        proxy_patterns=(
+            re.compile(r"(城市|地级市|省级).{0,12}(绿色)?专利", re.I),
+            re.compile(r"city[- ]level.*patent", re.I),
+        ),
+    ),
+    HardRequirement(
+        key="customs_hs",
+        label="海关/HS 贸易明细（非海外营收代理）",
+        pattern=re.compile(
+            r"(海关|HS.?码|HS code|customs|进出口明细|贸易明细)",
+            re.I,
+        ),
+        file_keywords=("海关", "customs", "hs", "进出口", "trade"),
+        proxy_patterns=(
+            re.compile(r"(海外营收|境外收入|overseas.?revenue).{0,20}(代理|proxy|替代)", re.I),
+            re.compile(r"用.{0,8}(海外|境外).{0,8}(营收|收入).{0,8}(代替|替代)", re.I),
+        ),
+    ),
+    HardRequirement(
+        key="bond_spreads",
+        label="债券利差/信用利差（非利息保障倍数代理）",
+        pattern=re.compile(
+            r"(债券利差|信用利差|credit.?spread|bond.?spread|公司债.?利差)",
+            re.I,
+        ),
+        file_keywords=("利差", "spread", "债券", "bond", "信用债"),
+        proxy_patterns=(
+            re.compile(r"(利息保障|interest.?coverage).{0,20}(代理|proxy|替代)", re.I),
+            re.compile(r"用.{0,8}利息保障.{0,8}(代替|替代).{0,8}利差", re.I),
+        ),
+    ),
+    HardRequirement(
+        key="carbon_quota",
+        label="碳配额/碳交易微观数据",
+        pattern=re.compile(
+            r"(碳配额|碳排放权|碳交易.*企业|ETS.*firm|碳市场.*配额)",
+            re.I,
+        ),
+        file_keywords=("碳", "carbon", "ets", "配额", "cea"),
+        proxy_patterns=(),
+    ),
+)
+
+
+@dataclass
+class TopicIntegrityReport:
+    requirements: list[str] = field(default_factory=list)
+    satisfied: list[str] = field(default_factory=list)
+    hard_gaps: list[str] = field(default_factory=list)
+    proxy_warnings: list[str] = field(default_factory=list)
+    data_root_note: str = ""
+    candidate_files: dict[str, list[str]] = field(default_factory=dict)
+
+    @property
+    def ok_for_causal_empirics(self) -> bool:
+        return not self.hard_gaps
+
+    def to_skipped_items(self) -> list[dict]:
+        items = []
+        for gap in self.hard_gaps:
+            items.append(
+                {
+                    "item": f"empirics:{gap}",
+                    "reason": (
+                        f"TOPIC 硬性要求「{gap}」在本地实证数据根中未找到可匹配面板；"
+                        "禁止用代理变量完成因果实证并交付 PDF。"
+                    ),
+                    "fix_hint": (
+                        "将匹配面板放入 FINAI_EMPIRICAL_DATA_ROOT，或收窄 TOPIC 去掉该硬性要求；"
+                        "写作管线可继续，但不得声称已完成该识别。"
+                    ),
+                }
+            )
+        return items
+
+
+def assess_topic_integrity(
+    topic_text: str,
+    *,
+    data_root: EmpiricalDataRoot | None = None,
+    artifact_text: str = "",
+) -> TopicIntegrityReport:
+    """Assess TOPIC hard requirements against local empirical root (+ optional artifacts)."""
+    text = topic_text or ""
+    root = data_root or resolve_empirical_data_root()
+    report = TopicIntegrityReport(
+        data_root_note=(
+            f"{root.path} (source={root.source}, available={root.available})"
+            if root.path
+            else "FINAI_EMPIRICAL_DATA_ROOT unset / missing"
+        )
+    )
+    blob = text + "\n" + (artifact_text or "")
+
+    for req in _HARD:
+        if not req.pattern.search(text):
+            continue
+        report.requirements.append(req.key)
+        hits = find_candidate_files(list(req.file_keywords), root) if root.available else []
+        report.candidate_files[req.key] = [str(h) for h in hits[:10]]
+        if hits:
+            report.satisfied.append(req.key)
+        else:
+            report.hard_gaps.append(req.key)
+        for pp in req.proxy_patterns:
+            if pp.search(blob):
+                report.proxy_warnings.append(
+                    f"{req.key}: artifact/TOPIC suggests forbidden proxy ({req.label})"
+                )
+                break
+    return report

--- a/scripts/universal_data_fetcher.py
+++ b/scripts/universal_data_fetcher.py
@@ -4,8 +4,9 @@ universal_data_fetcher.py
 经济金融研究统一数据获取模块。
 
 【设计原则】
-每个数据需求都有4层fallback，确保任何情况下都能获取数据或明确标记为模拟：
+每个数据需求都有分层 fallback，确保任何情况下都能获取数据或明确标记为模拟：
 
+  Layer 0: 本地实证数据根（FINAI_EMPIRICAL_DATA_ROOT /data/实证分析）
   Layer 1: MCP调用（Cursor MCP Tool，通过CallMcpTool）
   Layer 2: Python CLI库（akshare/yfinance/baostock，直接pip安装）
   Layer 3: 原始HTTP请求（requests/urllib，无需特殊库）
@@ -75,6 +76,7 @@ sys.path.insert(0, str(_PROJECT_ROOT))
 # ─── 数据来源枚举 ───────────────────────────────────────────────────────────────
 
 class DataSource(str, Enum):
+    LOCAL_EMPIRICAL = "local_empirical"  # FINAI_EMPIRICAL_DATA_ROOT
     MCP = "mcp"              # MCP服务器
     CLI_AKSHARE = "cli_akshare"    # akshare Python库
     CLI_BAOSTOCK = "cli_baostock"  # baostock Python库
@@ -85,6 +87,7 @@ class DataSource(str, Enum):
     @property
     def tier(self) -> int:
         tier_map = {
+            DataSource.LOCAL_EMPIRICAL: 0,
             DataSource.MCP: 1,
             DataSource.CLI_AKSHARE: 2,
             DataSource.CLI_BAOSTOCK: 2,
@@ -174,6 +177,49 @@ class DataFetcher:
         self.name = name
         self._provenance: list[str] = []
 
+    def try_local_empirical(self, *args, **kwargs) -> tuple[bool, Any, str]:
+        """Layer 0: shared empirical data root (FINAI_EMPIRICAL_DATA_ROOT).
+
+        Looks for csv/parquet/dta under the resolved root whose path matches
+        ``local_keywords`` / ``empirical_keywords`` or ``self.name``.
+        """
+        keywords = kwargs.get("local_keywords") or kwargs.get("empirical_keywords")
+        if keywords is None:
+            keywords = [self.name.replace("_", " "), self.name]
+        if isinstance(keywords, str):
+            keywords = [keywords]
+        try:
+            from scripts.core.empirical_data_root import (
+                find_candidate_files,
+                resolve_empirical_data_root,
+            )
+        except Exception as e:  # pragma: no cover
+            return False, None, f"empirical_data_root import failed: {e}"
+        root = resolve_empirical_data_root()
+        if not root.available:
+            return False, None, f"empirical root unavailable ({root.source})"
+        hits = find_candidate_files(list(keywords), root)
+        if not hits:
+            return False, None, "no matching local empirical files"
+        path = hits[0]
+        try:
+            suffix = path.suffix.lower()
+            if suffix == ".csv":
+                data = pd.read_csv(path)
+            elif suffix in {".parquet", ".pq"}:
+                data = pd.read_parquet(path)
+            elif suffix == ".dta":
+                data = pd.read_stata(path)
+            elif suffix in {".xlsx", ".xls"}:
+                data = pd.read_excel(path)
+            else:
+                return False, None, f"unsupported local suffix: {suffix}"
+            if data is None or (hasattr(data, "empty") and data.empty):
+                return False, None, f"empty local file: {path}"
+            return True, data, str(path)
+        except Exception as e:
+            return False, None, f"local load failed: {e}"
+
     def try_mcp(self, *args, **kwargs) -> tuple[bool, Any, str]:
         """Layer 1: 尝试MCP调用。子类应该重写此方法。
 
@@ -218,6 +264,21 @@ class DataFetcher:
                 **永远不要** 设为 True。
         """
         provenance = []
+
+        # Layer 0: local empirical data root (before remote MCP)
+        try:
+            ok, data, err = self.try_local_empirical(*args, **kwargs)
+            if ok and data is not None:
+                provenance.append("local_empirical")
+                return DataResult(
+                    data=data,
+                    source=DataSource.LOCAL_EMPIRICAL,
+                    provenance="→".join(provenance),
+                    available=True,
+                )
+            provenance.append(f"local_miss:{(err or 'none')[:40]}")
+        except Exception as e:
+            provenance.append(f"local_err:{str(e)[:30]}")
 
         # Layer 1: MCP
         try:
@@ -303,8 +364,10 @@ class AStockFinancialFetcher(DataFetcher):
         # 注意：MCP调用需要在Cursor中通过CallMcpTool执行
         # 这里检查环境变量是否有token，但不实际调用MCP
         from dotenv import load_dotenv
+        # Never override already-exported Cursor/shell env (e.g. TUSHARE_TOKEN,
+        # FINAI_EMPIRICAL_DATA_ROOT). Empty .env.local values must not wipe them.
         load_dotenv(_PROJECT_ROOT / ".env", override=False)
-        load_dotenv(_PROJECT_ROOT / ".env.local", override=True)
+        load_dotenv(_PROJECT_ROOT / ".env.local", override=False)
         import os
         token = os.getenv("TUSHARE_TOKEN", "").strip()
         if not token:

--- a/tests/test_empirical_integrity.py
+++ b/tests/test_empirical_integrity.py
@@ -1,0 +1,177 @@
+"""Tests for empirical data root, TOPIC integrity, delivery contract, host wiring."""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+
+def test_resolve_empirical_data_root_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    from scripts.core.empirical_data_root import resolve_empirical_data_root
+
+    monkeypatch.delenv("FINAI_EMPIRICAL_DATA_ROOT", raising=False)
+    data = tmp_path / "panels"
+    data.mkdir()
+    (data / "green_patent_firm.csv").write_text("a,b\n1,2\n", encoding="utf-8")
+    monkeypatch.setenv("FINAI_EMPIRICAL_DATA_ROOT", str(data))
+    root = resolve_empirical_data_root()
+    assert root.available
+    assert root.source == "env"
+    assert root.path == data.resolve() or root.path == data
+
+
+def test_find_candidate_files(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    from scripts.core.empirical_data_root import find_candidate_files, resolve_empirical_data_root
+
+    monkeypatch.setenv("FINAI_EMPIRICAL_DATA_ROOT", str(tmp_path))
+    (tmp_path / "firm_green_patent_2019.csv").write_text("x\n1\n", encoding="utf-8")
+    (tmp_path / "unrelated.txt").write_text("nope", encoding="utf-8")
+    root = resolve_empirical_data_root()
+    hits = find_candidate_files(["green_patent", "专利"], root)
+    assert any("green_patent" in str(h) for h in hits)
+
+
+def test_topic_integrity_hard_gaps_without_panels(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    from scripts.core.topic_integrity import assess_topic_integrity
+    from scripts.core.empirical_data_root import resolve_empirical_data_root
+
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    monkeypatch.setenv("FINAI_EMPIRICAL_DATA_ROOT", str(empty))
+    topic = "使用企业级绿色专利与海关HS码、债券利差完成DID实证"
+    report = assess_topic_integrity(topic, data_root=resolve_empirical_data_root())
+    assert "firm_green_patents" in report.hard_gaps
+    assert "customs_hs" in report.hard_gaps
+    assert "bond_spreads" in report.hard_gaps
+    assert not report.ok_for_causal_empirics
+    skips = report.to_skipped_items()
+    assert any("empirics:" in s["item"] for s in skips)
+
+
+def test_topic_integrity_satisfied_when_files_exist(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    from scripts.core.topic_integrity import assess_topic_integrity
+    from scripts.core.empirical_data_root import resolve_empirical_data_root
+
+    monkeypatch.setenv("FINAI_EMPIRICAL_DATA_ROOT", str(tmp_path))
+    (tmp_path / "企业绿色专利面板.csv").write_text("id,y\n1,0\n", encoding="utf-8")
+    topic = "研究企业级绿色专利与数字金融"
+    report = assess_topic_integrity(topic, data_root=resolve_empirical_data_root())
+    assert "firm_green_patents" in report.satisfied
+    assert "firm_green_patents" not in report.hard_gaps
+
+
+def test_topic_integrity_proxy_warning():
+    from scripts.core.topic_integrity import assess_topic_integrity
+
+    topic = "需要海关HS码贸易明细"
+    artifact = "本文用海外营收作为海关数据的代理变量完成回归"
+    report = assess_topic_integrity(topic, artifact_text=artifact)
+    assert any("customs_hs" in w for w in report.proxy_warnings)
+
+
+def test_delivery_contract_requires_final_and_skipped(tmp_path: Path):
+    from scripts.core.delivery_contract import validate_delivery
+
+    (tmp_path / "CODEX_FINAL.md").write_text("# x\n", encoding="utf-8")
+    (tmp_path / "main.pdf").write_bytes(b"%PDF-1.4")
+    bad = validate_delivery(tmp_path, require_pdf=True, allow_alias_final=True)
+    assert not bad.ok
+    assert "FINAL.md" in bad.missing
+    assert "SKIPPED_CONFIG.md" in bad.missing
+
+    (tmp_path / "FINAL.md").write_text("# FINAL\n", encoding="utf-8")
+    (tmp_path / "SKIPPED_CONFIG.md").write_text("# SKIP\n", encoding="utf-8")
+    good = validate_delivery(tmp_path, require_pdf=True)
+    assert good.ok
+
+
+def test_datafetcher_layer0_local_empirical(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    from scripts.universal_data_fetcher import DataFetcher, DataSource
+
+    monkeypatch.setenv("FINAI_EMPIRICAL_DATA_ROOT", str(tmp_path))
+    (tmp_path / "a_stock_financial_demo.csv").write_text(
+        "ts_code,rev\n000001.SZ,1\n", encoding="utf-8"
+    )
+
+    class Stub(DataFetcher):
+        def try_mcp(self, *a, **k):
+            raise NotImplementedError("should not need mcp")
+
+    fetcher = Stub("a_stock_financial")
+    result = fetcher.fetch(local_keywords=["a_stock_financial"])
+    assert result.available
+    assert result.source == DataSource.LOCAL_EMPIRICAL
+    assert isinstance(result.data, pd.DataFrame)
+    assert "local_empirical" in result.provenance
+
+
+def test_dotenv_override_false_in_astock_fetcher():
+    """Regression: .env.local must not wipe exported env with override=True."""
+    import inspect
+    from scripts.universal_data_fetcher import AStockFinancialFetcher
+
+    src = inspect.getsource(AStockFinancialFetcher.try_mcp)
+    assert "override=True" not in src
+    assert "override=False" in src
+
+
+def test_agent_host_entry_records_topic_gaps(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("FINAI_EMPIRICAL_DATA_ROOT", str(tmp_path / "nope_missing"))
+    (tmp_path / "TOPIC.md").write_text(
+        "# T\n\n使用企业级绿色专利完成碳排放权交易DID\n",
+        encoding="utf-8",
+    )
+    from scripts.agent_host_entry import main
+
+    with patch("scripts.health_check.run_diagnostic") as diag:
+        diag.return_value = MagicMock(llm_available=True, llm_status="ok")
+        code = main(
+            [
+                "--output-dir",
+                str(tmp_path / "output"),
+                "--dry-run-preflight",
+                "--check-delivery",
+            ]
+        )
+    assert code == 0
+    skipped = (tmp_path / "output" / "SKIPPED_CONFIG.md").read_text(encoding="utf-8")
+    assert "empirics:" in skipped or "企业级绿色专利" in skipped or "firm_green"
+    assert (tmp_path / "output" / "DELIVERY.md").is_file()
+    final = (tmp_path / "output" / "FINAL.md").read_text(encoding="utf-8")
+    assert "do **not** invent a parallel pipeline" in final or "parallel pipeline" in final
+
+
+def test_agent_host_block_on_topic_gaps(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    monkeypatch.setenv("FINAI_EMPIRICAL_DATA_ROOT", str(empty))
+    from scripts.agent_host_entry import main
+
+    with patch("scripts.health_check.run_diagnostic") as diag:
+        diag.return_value = MagicMock(llm_available=True, llm_status="ok")
+        code = main(
+            [
+                "--topic",
+                "企业级绿色专利与海关HS码的因果识别",
+                "--output-dir",
+                str(tmp_path / "output"),
+                "--block-on-topic-gaps",
+            ]
+        )
+    assert code == 4
+    text = (tmp_path / "output" / "SKIPPED_CONFIG.md").read_text(encoding="utf-8")
+    assert "empirics:" in text


### PR DESCRIPTION
## Summary
- Audit of test-user chats (`xzy talk`) / outputs showed freestyle empirics, ignored `FINAI_EMPIRICAL_DATA_ROOT`, and proxy-laundered causal PDFs (city patents / overseas revenue / interest coverage).
- Wire Layer-0 local empirical fetch; stop `.env.local` from wiping exported env (`override=False`).
- Harden `agent_host_entry`: TOPIC hard-gap skips, optional `--block-on-topic-gaps`, delivery contract (`FINAL.md` + `SKIPPED_CONFIG.md`), autopilot next-actions.
- Docs/rules: `AGENTS.md`, `.env.example`, `.cursor/rules/agent-host-isolation.mdc`.

## Test plan
- [x] `pytest tests/test_empirical_integrity.py tests/test_agent_host_entry.py` (15 passed)
- [x] Broader: `test_orchestrator_hitl_resume` + `test_pipeline_entry_fixes` (38 passed total)
- [ ] CI green on PR
- [ ] Manual: `FINAI_EMPIRICAL_DATA_ROOT=/tmp/empty python scripts/agent_host_entry.py --topic "企业级绿色专利DID" --dry-run-preflight --check-delivery`


Made with [Cursor](https://cursor.com)