### PR TITLE
fix: official empirics explore + data redundancy (no silent demo)

### DIFF
--- a/.cursor/rules/agent-host-isolation.mdc
+++ b/.cursor/rules/agent-host-isolation.mdc
@@ -8,13 +8,16 @@ alwaysApply: false
 
 When the user (or slot) requires **no questions, no wait, no Mock**:
 
-1. Prefer `python scripts/agent_host_entry.py` — do **not** freestyle `run_real_*.py`.
-2. Set / respect `FINAI_EMPIRICAL_DATA_ROOT` (default candidates include `/data/实证分析`).
-   Check local panels **before** remote fetch or proxy substitution.
+1. Prefer `python scripts/agent_host_entry.py` for writing; for empirics prefer
+   `python -m scripts.research_framework.enhanced_pipeline --explore --panel ...`
+   (or `modern_did` / `robustness_runner`). Thin official results are a product bug —
+   deepen **inside** FinAI, don't invent `run_real_*.py` outside the APIs.
+2. Set / respect `FINAI_EMPIRICAL_DATA_ROOT`. Local panels before remote / proxy.
 3. Never substitute: city patents → firm green patents; overseas revenue → customs HS;
    interest coverage → bond spreads. Record hard-gaps in `SKIPPED_CONFIG.md`.
 4. Delivery must include `FINAL.md` + `SKIPPED_CONFIG.md` (not only `CODEX_FINAL.md` / PDF).
 5. Writing success with empirics gaps = `partial`, not journal-ready causal completion.
 6. Do not start MCP servers unless the user asked; do not invent coefficients.
+7. Demo/Mock panels require explicit `--allow-demo` / `allow_synthetic=True`.
 
 Interactive research chats (no autopilot) still follow `system-init.mdc` greet + HITL.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,16 +63,20 @@ When a host agent is told **not to ask**, **not to wait**, and **not to use Mock
 4. Empirical work (DID/IV/data fetch) remains a **separate hand-off** from the writing pipeline; see dual-track notes in `docs/ARCHITECTURE.md`.
 5. Batch HITL off: default for `agent_host_entry`; or `FINAI_NO_HITL=1` / `--no-use-hitl` on other CLIs.
 6. **Local empirics first**: set `FINAI_EMPIRICAL_DATA_ROOT` (e.g. `/data/实证分析`).
-   `DataFetcher.fetch` Layer 0 reads this root before MCP/CLI. Skipping local panels
-   and substituting city patents / overseas revenue / interest coverage for
+   Universal + CachedDataFetcher Layer 0 read this root before MCP/CLI. Skipping local
+   panels and substituting city patents / overseas revenue / interest coverage for
    firm green patents / customs HS / bond spreads is **proxy laundering** — forbidden.
-7. **TOPIC integrity**: `agent_host_entry` records hard-gaps in `SKIPPED_CONFIG.md`.
+7. **Deepen inside FinAI, don't fork outside**: if results are thin, use
+   `python -m scripts.research_framework.enhanced_pipeline --topic "..." --explore
+   [--panel path]` (multi-estimator + comprehensive robustness). Freestyle
+   `run_real_*.py` that bypasses FinAI APIs / local root is the anti-pattern.
+8. **TOPIC integrity**: `agent_host_entry` records hard-gaps in `SKIPPED_CONFIG.md`.
    Writing may continue as `status=partial` with non-claims; use `--block-on-topic-gaps`
    to refuse the whole run. Causal PDF delivery is not "completed" while gaps remain.
-8. **Delivery contract**: required artifacts are `FINAL.md` + `SKIPPED_CONFIG.md`
+9. **Delivery contract**: required artifacts are `FINAL.md` + `SKIPPED_CONFIG.md`
    (`CODEX_FINAL.md` alone is insufficient). Optional: `--check-delivery` → `DELIVERY.md`.
-9. Interactive Cursor chats still greet / HITL per `.cursor/rules/system-init.mdc`;
-   isolation autopilot overrides that via `FINAI_AUTOPILOT=1` + `agent_host_entry` only.
+10. Interactive Cursor chats still greet / HITL per `.cursor/rules/system-init.mdc`;
+    isolation autopilot overrides that via `FINAI_AUTOPILOT=1` + `agent_host_entry` only.
 
 ---
 

--- a/scripts/SCRIPTS_INDEX.md
+++ b/scripts/SCRIPTS_INDEX.md
@@ -10,12 +10,12 @@
 | 分类 | 数量 | 说明 |
 |------|------|------|
 | 🚀 Entry Points (`scripts/*.py`) | 106 | 顶级入口脚本（含 CLI） |
-| 📦 Core Modules (`scripts/core/`) | 109 | 核心库（被其他模块导入）|
+| 📦 Core Modules (`scripts/core/`) | 110 | 核心库（被其他模块导入）|
 | 📊 Research Framework (`scripts/research_framework/`) | 59 | 计量方法模块 |
 | 🧭 Research Directions (`scripts/research_directions/`) | 15 | 研究方向领域 |
-| 🧪 Tests (`tests/`) | 675 | 测试文件 |
+| 🧪 Tests (`tests/`) | 676 | 测试文件 |
 | 🔌 MCP Servers (`mcp_servers/user_*/`) | 43 | MCP 数据源 |
-| **合计（仅 Python 文件）** | **964** | 不含 MCP / docs / tests fixtures |
+| **合计（仅 Python 文件）** | **966** | 不含 MCP / docs / tests fixtures |
 
 > 自动生成于 2026-08-08
 ---

--- a/scripts/core/agent_host_report.py
+++ b/scripts/core/agent_host_report.py
@@ -114,21 +114,24 @@ def write_host_reports(report: HostRunReport) -> tuple[Path, Path]:
     autopilot = os.environ.get("FINAI_AUTOPILOT", "").strip() in {"1", "true", "yes"}
     if autopilot or report.entry.endswith("agent_host_entry.py"):
         final_lines += [
-            "1. If **blocked**: fix SKIPPED items, then re-run "
-            "`python scripts/agent_host_entry.py` — do **not** invent a parallel pipeline.",
-            "2. If **partial** with empirics hard-gaps: writing may exist; "
-            "**do not** claim causal DID/IV results or ship proxy-laundered empirics.",
-            "3. Empirics hand-off: set `FINAI_EMPIRICAL_DATA_ROOT`, place matching panels, "
-            "then use `enhanced_pipeline` / `modern_did` (not freestyle `run_real_*.py`).",
-            "4. Delivery contract requires `FINAL.md` + `SKIPPED_CONFIG.md` "
-            "(not `CODEX_FINAL.md` alone).",
+            "1. If blocked: fix SKIPPED items, then re-run "
+            "python scripts/agent_host_entry.py. Prefer official FinAI entrypoints.",
+            "2. If partial with empirics hard-gaps: writing may exist; "
+            "do not claim causal DID/IV or substitute proxy outcomes "
+            "(city patents / overseas revenue / interest coverage).",
+            "3. Empirics: set FINAI_EMPIRICAL_DATA_ROOT, then deepen inside FinAI via "
+            "python -m scripts.research_framework.enhanced_pipeline --explore --panel <path> "
+            "(local->MCP redundancy + multi-estimator suite). "
+            "Do not invent a second stack outside FinAI APIs.",
+            "4. Delivery contract requires FINAL.md + SKIPPED_CONFIG.md "
+            "(not CODEX_FINAL.md alone).",
             "",
         ]
     else:
         final_lines += [
-            "1. Configure at least one LLM (`DEEPSEEK_API_KEY` or `RELAY_API_KEY` or Ollama).",
-            "2. Re-run: `python scripts/agent_host_entry.py --topic \"...\"`",
-            "3. Interactive path (human TTY): `python scripts/start_research.py --topic \"...\"`",
+            "1. Configure at least one LLM (DEEPSEEK_API_KEY or RELAY_API_KEY or Ollama).",
+            "2. Re-run: python scripts/agent_host_entry.py --topic '...'",
+            "3. Interactive path (human TTY): python scripts/start_research.py --topic '...'",
             "",
         ]
 

--- a/scripts/core/empirical_data_root.py
+++ b/scripts/core/empirical_data_root.py
@@ -41,31 +41,41 @@ def resolve_empirical_data_root(
     *,
     env_var: str = "FINAI_EMPIRICAL_DATA_ROOT",
 ) -> EmpiricalDataRoot:
-    """Resolve the shared empirical data directory (read-only usage)."""
-    candidates: list[tuple[str, str]] = []
+    """Resolve the shared empirical data directory (read-only usage).
+
+    Explicit path / ``FINAI_EMPIRICAL_DATA_ROOT`` win. When either is set but
+    missing/unreadable, do **not** silently fall through to repo ``data/`` —
+    that hid empty roots and pulled demo panels during isolation runs.
+    Defaults apply only when neither explicit nor env is set.
+    """
     if explicit:
-        candidates.append((str(explicit), "explicit"))
+        p = Path(os.path.expanduser(str(explicit))).resolve()
+        if p.is_dir():
+            return EmpiricalDataRoot(
+                path=p, source="explicit", exists=True, readable=os.access(p, os.R_OK)
+            )
+        return EmpiricalDataRoot(path=p, source="explicit", exists=False, readable=False)
+
     env_val = (os.environ.get(env_var) or "").strip()
     if env_val:
-        candidates.append((env_val, "env"))
-    for c in _DEFAULT_CANDIDATES:
-        candidates.append((c, "default"))
+        p = Path(os.path.expanduser(env_val)).resolve()
+        if p.is_dir():
+            return EmpiricalDataRoot(
+                path=p, source="env", exists=True, readable=os.access(p, os.R_OK)
+            )
+        return EmpiricalDataRoot(path=p, source="env", exists=False, readable=False)
 
     seen: set[str] = set()
-    for raw, source in candidates:
+    for raw in _DEFAULT_CANDIDATES:
         key = os.path.abspath(os.path.expanduser(raw))
         if key in seen:
             continue
         seen.add(key)
         p = Path(key)
         if p.is_dir():
-            readable = os.access(p, os.R_OK)
-            return EmpiricalDataRoot(path=p, source=source, exists=True, readable=readable)
-
-    # Prefer env path even if missing (so reports show the intended root)
-    if env_val:
-        p = Path(os.path.expanduser(env_val)).resolve()
-        return EmpiricalDataRoot(path=p, source="env", exists=False, readable=False)
+            return EmpiricalDataRoot(
+                path=p, source="default", exists=True, readable=os.access(p, os.R_OK)
+            )
     return EmpiricalDataRoot(path=None, source="missing", exists=False, readable=False)
 
 

--- a/scripts/core/empirical_explore.py
+++ b/scripts/core/empirical_explore.py
@@ -1,0 +1,239 @@
+"""Official empirical exploration helpers (reuse FinAI estimators; no parallel stack).
+
+Motivation (test-user audit): agents freestyled ``run_real_*.py`` because the
+official path was thin (demo panel + one DID + six hand-picked robustness
+tests) while still telling them not to invent a second stack.
+
+This module:
+  1. Loads panels with redundancy: local empirical root → optional path → caller
+  2. Explores multiple *existing* ModernDiDEngine estimators (fail soft per method)
+  3. Does NOT invent coefficients, Mock panels, or proxy outcomes
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable
+
+import pandas as pd
+
+__all__ = [
+    "PanelLoadResult",
+    "ExploreReport",
+    "load_panel_redundant",
+    "explore_did_suite",
+    "topic_local_keywords",
+]
+
+_log = logging.getLogger("empirical_explore")
+
+# Estimators that exist on ModernDiDEngine today (do not list advertised-but-missing sa/dCdH).
+_SUITE_STANDARD: tuple[str, ...] = (
+    "did_2x2",
+    "parallel_trends_test",
+    "bacon",
+    "honest_did",
+    "cs",
+)
+_SUITE_EXPLORE: tuple[str, ...] = _SUITE_STANDARD + (
+    "bjs",
+    "gardner",
+    "event_study_data",
+)
+
+
+@dataclass
+class PanelLoadResult:
+    df: pd.DataFrame | None
+    source: str  # local_empirical | path | empty
+    path: str = ""
+    tried: list[str] = field(default_factory=list)
+    error: str = ""
+
+    @property
+    def ok(self) -> bool:
+        return self.df is not None and not self.df.empty
+
+
+@dataclass
+class ExploreReport:
+    results: dict[str, Any] = field(default_factory=dict)
+    succeeded: list[str] = field(default_factory=list)
+    skipped: list[str] = field(default_factory=list)
+    errors: dict[str, str] = field(default_factory=dict)
+    level: str = "standard"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "level": self.level,
+            "succeeded": list(self.succeeded),
+            "skipped": list(self.skipped),
+            "errors": dict(self.errors),
+            "results": self.results,
+        }
+
+
+def topic_local_keywords(topic: str) -> list[str]:
+    """Derive filesystem keywords from a research topic (CN/EN mix)."""
+    text = (topic or "").strip()
+    if not text:
+        return []
+    keys = [
+        "绿色专利",
+        "patent",
+        "海关",
+        "customs",
+        "利差",
+        "spread",
+        "债券",
+        "bond",
+        "碳",
+        "carbon",
+        "esg",
+        "panel",
+        "面板",
+        "did",
+    ]
+    hits = [k for k in keys if k.lower() in text.lower()]
+    # Always include a few coarse tokens from the topic itself
+    for tok in text.replace("，", " ").replace(",", " ").split():
+        t = tok.strip()
+        if len(t) >= 2:
+            hits.append(t)
+    # de-dupe preserve order
+    seen: set[str] = set()
+    out: list[str] = []
+    for h in hits:
+        if h.lower() not in seen:
+            seen.add(h.lower())
+            out.append(h)
+    return out[:24]
+
+
+def load_panel_redundant(
+    *,
+    topic: str = "",
+    panel_path: str | Path | None = None,
+    keywords: list[str] | None = None,
+    allow_empty: bool = True,
+) -> PanelLoadResult:
+    """Try local empirical root / explicit path. No Mock, no remote invent.
+
+    Remote MCP/CLI remains the caller's job (enhanced_pipeline / UniversalDataFetcher).
+    This function only hardens the *local redundancy* layer that agents skipped.
+    """
+    tried: list[str] = []
+    keys = list(keywords or []) or topic_local_keywords(topic)
+
+    if panel_path:
+        p = Path(panel_path).expanduser()
+        tried.append(f"path:{p}")
+        if p.is_file():
+            try:
+                df = _read_table(p)
+                if df is not None and not df.empty:
+                    return PanelLoadResult(df=df, source="path", path=str(p), tried=tried)
+            except Exception as exc:
+                tried.append(f"path_err:{exc}")
+
+    try:
+        from scripts.core.empirical_data_root import (
+            find_candidate_files,
+            resolve_empirical_data_root,
+        )
+    except Exception as exc:
+        return PanelLoadResult(
+            df=None, source="empty", tried=tried, error=f"import failed: {exc}"
+        )
+
+    root = resolve_empirical_data_root()
+    tried.append(f"root:{root.path}:{root.source}:available={root.available}")
+    if root.available and keys:
+        hits = find_candidate_files(keys, root)
+        tried.append(f"hits:{len(hits)}")
+        for hit in hits[:5]:
+            try:
+                df = _read_table(hit)
+                if df is not None and not df.empty:
+                    return PanelLoadResult(
+                        df=df, source="local_empirical", path=str(hit), tried=tried
+                    )
+            except Exception as exc:
+                tried.append(f"load_err:{hit.name}:{exc}")
+
+    if allow_empty:
+        return PanelLoadResult(df=None, source="empty", tried=tried, error="no local panel")
+    raise FileNotFoundError(
+        "No local panel under FINAI_EMPIRICAL_DATA_ROOT / --panel. "
+        f"Tried: {tried}"
+    )
+
+
+def explore_did_suite(
+    engine: Any,
+    *,
+    level: str = "standard",
+    cluster_var: str | None = None,
+) -> ExploreReport:
+    """Run multiple ModernDiDEngine methods; each failure is recorded, not fatal.
+
+    level:
+      - standard: 2x2 + PT + Bacon + Honest + CS
+      - explore:  standard + BJS + Gardner + event_study_data
+    """
+    names = list(_SUITE_EXPLORE if level == "explore" else _SUITE_STANDARD)
+    report = ExploreReport(level=level)
+
+    for name in names:
+        fn = getattr(engine, name, None)
+        if not callable(fn):
+            report.skipped.append(name)
+            report.errors[name] = "method missing on ModernDiDEngine"
+            continue
+        try:
+            out = _call_estimator(fn, name, cluster_var=cluster_var)
+            report.results[name] = out
+            report.succeeded.append(name)
+        except Exception as exc:
+            report.skipped.append(name)
+            report.errors[name] = str(exc)[:240]
+            _log.info("[explore] %s skipped: %s", name, exc)
+
+    return report
+
+
+def _call_estimator(fn: Callable, name: str, *, cluster_var: str | None) -> Any:
+    if name == "did_2x2":
+        res = fn(cluster_var=cluster_var) if cluster_var else fn()
+        return res.to_dict() if hasattr(res, "to_dict") else res
+    if name == "parallel_trends_test":
+        return fn()
+    if name == "bacon":
+        df = fn()
+        if isinstance(df, pd.DataFrame):
+            return df.to_dict("records") if not df.empty else {}
+        return df
+    if name == "honest_did":
+        return fn(m=0.5)
+    if name == "event_study_data":
+        data = fn()
+        if isinstance(data, pd.DataFrame):
+            return data.to_dict("records") if not data.empty else {}
+        return data
+    # cs / bjs / gardner
+    res = fn()
+    return res.to_dict() if hasattr(res, "to_dict") else res
+
+
+def _read_table(path: Path) -> pd.DataFrame | None:
+    suffix = path.suffix.lower()
+    if suffix == ".csv":
+        return pd.read_csv(path)
+    if suffix in {".parquet", ".pq"}:
+        return pd.read_parquet(path)
+    if suffix == ".dta":
+        return pd.read_stata(path)
+    if suffix in {".xlsx", ".xls"}:
+        return pd.read_excel(path)
+    return None

--- a/scripts/research_framework/data_fetcher.py
+++ b/scripts/research_framework/data_fetcher.py
@@ -1077,6 +1077,64 @@ class CachedDataFetcher(DataFetcher):
         """
         from scripts.core.data_cache import FallbackChain
 
+        # Layer 0: shared empirical data root (same contract as universal_data_fetcher)
+        try:
+            from scripts.core.empirical_data_root import (
+                find_candidate_files,
+                resolve_empirical_data_root,
+            )
+
+            root = resolve_empirical_data_root()
+            keys = []
+            for k in (
+                "local_keywords",
+                "empirical_keywords",
+                "ticker",
+                "symbol",
+                "query",
+            ):
+                v = args.get(k)
+                if isinstance(v, (list, tuple)):
+                    keys.extend(str(x) for x in v if x)
+                elif v:
+                    keys.append(str(v))
+            keys.append(chain_name or "panel")
+            if root.available and keys:
+                hits = find_candidate_files(keys, root, limit=5)
+                for hit in hits:
+                    try:
+                        suffix = hit.suffix.lower()
+                        if suffix == ".csv":
+                            frame = pd.read_csv(hit)
+                        elif suffix in {".parquet", ".pq"}:
+                            frame = pd.read_parquet(hit)
+                        elif suffix == ".dta":
+                            frame = pd.read_stata(hit)
+                        else:
+                            continue
+                        if frame is None or getattr(frame, "empty", True):
+                            continue
+                        payload = {
+                            "data": frame.to_dict("records"),
+                            "_source": "local_empirical",
+                            "_path": str(hit),
+                        }
+                        self.tracker.record(
+                            f"fallback:{chain_name}",
+                            DataSource.MANUAL,
+                            detail=f"local_empirical:{hit.name}",
+                        )
+                        _log.info(
+                            "[CachedDataFetcher] Layer0 local hit: %s", hit
+                        )
+                        return payload
+                    except Exception as exc:
+                        _log.debug(
+                            "[CachedDataFetcher] local load miss %s: %s", hit, exc
+                        )
+        except Exception as exc:
+            _log.debug("[CachedDataFetcher] Layer0 unavailable: %s", exc)
+
         chain = FallbackChain(chain_name) if chain_name else FallbackChain()
         fallback_log: list[dict] = []
 

--- a/scripts/research_framework/enhanced_pipeline.py
+++ b/scripts/research_framework/enhanced_pipeline.py
@@ -119,16 +119,16 @@ class EnhancedPipeline:
 
     6 步增强流水线：
 
-      Step 1: 数据获取（复用原有 + CachedDataFetcher）
-      Step 2: 现代 DID 回归（modern_did.py — 替换手写 OLS）
-      Step 3: 稳健性检验（robustness_runner.py）
+      Step 1: 数据获取（本地实证根冗余 → CachedDataFetcher；demo 需显式允许）
+      Step 2: 现代 DID 回归（modern_did + optional multi-estimator explore）
+      Step 3: 稳健性检验（robustness_runner；explore 时用 comprehensive）
       Step 4: Validation Gate 评估（evolution_gate.py）
       Step 5: LaTeX 生成 + 即时验证（latex_diff.py + latex_lint.py）
       Step 6: PDF 视觉检查（pdf_vision_check.py）
 
     Usage
     -----
-        pipeline = EnhancedPipeline(topic="ESG and Financing Constraints")
+        pipeline = EnhancedPipeline(topic="ESG and Financing Constraints", explore=True)
         result = pipeline.run()
         print(result.summary())
     """
@@ -148,6 +148,10 @@ class EnhancedPipeline:
         enable_hitl: bool = True,
         hitl_timeout: int = 600,
         on_gate_approved: callable | None = None,
+        *,
+        explore: bool = False,
+        allow_demo: bool = False,
+        panel_path: str | Path | None = None,
         **kwargs,
     ):
         self.topic = topic
@@ -163,6 +167,10 @@ class EnhancedPipeline:
         self.enable_pdf_vision = enable_pdf_vision
         self.enable_sandbox = enable_sandbox
         self.enable_self_evolution = enable_self_evolution
+        # Official empirics depth (reuse FinAI modules; do not freestyle outside)
+        self.explore = bool(explore or kwargs.get("explore", False))
+        self.allow_demo = bool(allow_demo or kwargs.get("allow_demo", False))
+        self.panel_path = panel_path or kwargs.get("panel_path")
         self.enable_hitl = enable_hitl
         self.hitl_timeout = hitl_timeout
         # 审批通过回调：签名 on_gate_approved(stage_name: str, ctx: PipelineContext)
@@ -298,42 +306,88 @@ class EnhancedPipeline:
 
     def step1_load_data(self) -> pd.DataFrame:
         """
-        Step 1: 数据加载。
+        Step 1: 数据加载（冗余顺序，禁止静默 Mock）。
 
-        尝试使用 CachedDataFetcher（MCP 缓存优先）。
-        失败时生成演示面板数据。
+        1. ``--panel`` / ``FINAI_EMPIRICAL_DATA_ROOT`` 本地面板
+        2. CachedDataFetcher 远程/MCP 链
+        3. 演示数据 **仅** 当 ``allow_demo=True``
         """
-        _log.info("[Step 1] 数据加载")
+        _log.info("[Step 1] 数据加载（local → MCP → demo-opt-in）")
+        provenance: list[str] = []
+        data: Any = None
 
+        # Layer A: local empirical root / explicit panel
         try:
-            from scripts.research_framework.data_fetcher import CachedDataFetcher
+            from scripts.core.empirical_explore import load_panel_redundant
 
-            fetcher = CachedDataFetcher(
-                output_dir="data/",
-                enable_7layer_fallback=True,
-                enable_nl_router=False,
-                verbose=True,
+            local = load_panel_redundant(
+                topic=self.topic,
+                panel_path=self.panel_path,
             )
-
-            # 尝试获取演示数据
-            data = fetcher.fetch_with_fallback(
-                "stock_info",
-                {"ticker": "AAPL"},
-            )
-
-            if data:
-                _log.info("[Step 1] ✅ MCP 数据获取成功")
-            else:
-                _log.warning("[Step 1] MCP 获取失败，使用演示数据")
-                data = self._generate_demo_data()
-
+            provenance.extend(local.tried)
+            if local.ok:
+                _log.info("[Step 1] ✅ 本地面板: %s (%s)", local.path, local.source)
+                data = local.df
+                provenance.append(f"source:{local.source}")
         except Exception as exc:
-            _log.warning(f"[Step 1] CachedDataFetcher 不可用: {exc}，使用演示数据")
-            data = self._generate_demo_data()
+            provenance.append(f"local_err:{exc}")
+            _log.warning("[Step 1] 本地面板加载失败: %s", exc)
+
+        # Layer B: CachedDataFetcher (now also probes local root inside fallback)
+        if data is None:
+            try:
+                from scripts.research_framework.data_fetcher import CachedDataFetcher
+
+                fetcher = CachedDataFetcher(
+                    output_dir="data/",
+                    enable_7layer_fallback=True,
+                    enable_nl_router=False,
+                    verbose=True,
+                )
+                remote = fetcher.fetch_with_fallback(
+                    "stock_info",
+                    {"ticker": "AAPL", "local_keywords": [self.topic]},
+                )
+                if remote:
+                    _log.info("[Step 1] ✅ MCP/fallback 数据获取成功")
+                    data = remote
+                    provenance.append("source:cached_fallback")
+                else:
+                    provenance.append("mcp_miss")
+            except Exception as exc:
+                provenance.append(f"mcp_err:{exc}")
+                _log.warning("[Step 1] CachedDataFetcher 不可用: %s", exc)
+
+        # Layer C: demo only with explicit opt-in
+        if data is None:
+            if self.allow_demo:
+                _log.warning("[Step 1] 允许演示数据（allow_demo=True）")
+                data = self._generate_demo_data()
+                provenance.append("source:demo_opt_in")
+            else:
+                msg = (
+                    "无可用面板：请设置 FINAI_EMPIRICAL_DATA_ROOT / --panel，"
+                    "或显式传 allow_demo=True / --allow-demo（仅演示）。"
+                )
+                _log.error("[Step 1] %s", msg)
+                self.ctx.df = None
+                self.ctx.step_results["step1"] = {
+                    "status": "error",
+                    "error": msg,
+                    "provenance": provenance,
+                }
+                return pd.DataFrame()
 
         df = self._build_panel(data)
         self.ctx.df = df
-        self.ctx.step_results["step1"] = {"status": "ok", "n_obs": len(df)}
+        self.ctx.step_results["step1"] = {
+            "status": "ok" if not df.empty else "error",
+            "n_obs": len(df),
+            "provenance": provenance,
+            "simulated": bool(df.attrs.get("simulated") or (
+                not df.empty and "_simulated" in df.columns and bool(df["_simulated"].iloc[0])
+            )),
+        }
         return df
 
     def _generate_demo_data(self) -> list[dict]:
@@ -389,33 +443,41 @@ class EnhancedPipeline:
         else:
             df = pd.DataFrame()
 
-        # 确保有必要的列
+        # 确保有必要的列（不再静默换成 demo，除非 allow_demo）
         required_cols = ["ticker", "year", "roa", "esg_high", "post", "did"]
         missing = [c for c in required_cols if c not in df.columns]
         if missing:
-            _log.warning(f"[Step 1] 缺少列 {missing}，生成演示数据")
-            demo = self._generate_demo_data()
-            df = pd.DataFrame(demo)
+            if self.allow_demo:
+                _log.warning(
+                    "[Step 1] 缺少列 %s，allow_demo=True → 演示面板", missing
+                )
+                df = pd.DataFrame(self._generate_demo_data())
+            else:
+                _log.error(
+                    "[Step 1] 面板缺少 DID 列 %s；拒绝静默 demo。"
+                    "请提供含 treat/post/y 的面板，或 --allow-demo。",
+                    missing,
+                )
+                return pd.DataFrame()
 
-        return df.dropna(subset=["roa", "esg_high", "post", "did"])
+        keep = [c for c in ("roa", "esg_high", "post", "did") if c in df.columns]
+        return df.dropna(subset=keep) if keep else df
 
     # ── Step 2: Modern DID ─────────────────────────────────────────────────
 
     def step2_modern_did(self) -> dict[str, Any]:
         """
-        Step 2: 现代 DID 回归。
+        Step 2: 现代 DID 回归（官方多估计器探索，复用 ModernDiDEngine）。
 
-        集成 modern_did.py：
-          - did_2x2（替换原有手写 OLS）
-          - Callaway-Sant'Anna（交错 DiD）
-          - 平行趋势自动化检验
-          - Bacon 分解
-          - Honest DiD 敏感性分析
+        standard: 2x2 + PT + Bacon + Honest + CS
+        explore:  + BJS + Gardner + event_study_data
+        单估计器失败记入 skipped，不中断整步。
         """
-        _log.info("[Step 2] 现代 DID 回归")
+        level = "explore" if self.explore else "standard"
+        _log.info("[Step 2] 现代 DID 回归（level=%s）", level)
         results: dict[str, Any] = {}
 
-        if self.ctx.df is None:
+        if self.ctx.df is None or self.ctx.df.empty:
             _log.error("[Step 2] 无数据，跳过")
             return results
 
@@ -426,63 +488,49 @@ class EnhancedPipeline:
             return results
 
         try:
+            from scripts.core.empirical_explore import explore_did_suite
             from scripts.research_framework.modern_did import ModernDiDEngine
 
+            x_vars = [
+                c
+                for c in ("lev", "size", "tangibility", "mb", "cash_ratio")
+                if c in df.columns
+            ]
+            cluster = "sector" if "sector" in df.columns else None
             engine = ModernDiDEngine(
                 df=df,
                 y_var="roa",
                 treat_var="did",
                 time_var="post",
                 unit_var="ticker",
-                x_vars=["lev", "size", "tangibility", "mb", "cash_ratio"],
-                cluster_var="sector",
+                x_vars=x_vars,
+                cluster_var=cluster,
             )
 
-            # 2x2 DID（基准）
-            r2x2 = engine.did_2x2(cluster_var="sector")
-            results["did_2x2"] = r2x2.to_dict()
-            _log.info(
-                f"[Step 2] did_2x2: coef={r2x2.coef:+.4f} "
-                f"(p={r2x2.pval:.4f}), N={r2x2.n_obs}"
+            report = explore_did_suite(
+                engine, level=level, cluster_var=cluster
             )
+            # Normalize keys expected by later steps / summary
+            results = dict(report.results)
+            if "parallel_trends_test" in results and "parallel_trends" not in results:
+                results["parallel_trends"] = results["parallel_trends_test"]
+            if "bacon" in results and "bacon_decomp" not in results:
+                results["bacon_decomp"] = results["bacon"]
 
-            # 平行趋势
-            pt = engine.parallel_trends_test()
-            results["parallel_trends"] = pt
-            _log.info(
-                f"[Step 2] Parallel trends: p={pt.get('pval', 1):.3f}, "
-                f"TOST={'pass' if pt.get('toest_pass') else 'fail'}"
-            )
-
-            # Bacon 分解（如果有交错数据）
-            if "sector" in df.columns:
-                try:
-                    bacon_df = engine.bacon()
-                    results["bacon_decomp"] = bacon_df.to_dict("records") if not bacon_df.empty else {}
-                    _log.info(f"[Step 2] Bacon: {len(bacon_df)} comparisons")
-                except Exception as exc:
-                    _log.warning(f"[Step 2] Bacon 分解失败: {exc}")
-
-            # Honest DiD 敏感性
-            honest = engine.honest_did(m=0.5)
-            results["honest_did"] = honest
-            _log.info(
-                f"[Step 2] Honest DiD: breakdown δ={honest.get('breakdown_value', 'N/A')}"
-            )
-
-            # Callaway-Sant'Anna（如果 diff_in_diff2 可用）
-            try:
-                r_cs = engine.cs()
-                results["cs"] = r_cs.to_dict()
-                _log.info(
-                    f"[Step 2] CS: coef={r_cs.coef:+.4f} "
-                    f"(p={r_cs.pval:.4f})"
-                )
-            except Exception:
-                _log.info("[Step 2] diff_in_diff2 不可用，跳过 CS 估计")
+            for name in report.succeeded:
+                _log.info("[Step 2] ✅ %s", name)
+            for name, err in report.errors.items():
+                _log.info("[Step 2] skip %s: %s", name, err)
 
             self.ctx.modern_did_results = results
-            self.ctx.step_results["step2"] = {"status": "ok", "results": list(results.keys())}
+            self.ctx.step_results["step2"] = {
+                "status": "ok" if report.succeeded else "error",
+                "results": list(results.keys()),
+                "explore_level": level,
+                "succeeded": report.succeeded,
+                "skipped": report.skipped,
+                "errors": report.errors,
+            }
 
         except Exception as exc:
             _log.error(f"[Step 2] Modern DID 失败: {exc}")
@@ -520,6 +568,11 @@ class EnhancedPipeline:
         try:
             from scripts.research_framework.robustness_runner import RobustnessRunner
 
+            x_vars = [
+                c
+                for c in ("lev", "size", "tangibility", "mb", "cash_ratio")
+                if c in df.columns
+            ]
             runner = RobustnessRunner(
                 df=df,
                 baseline_result=base_result,
@@ -527,18 +580,21 @@ class EnhancedPipeline:
                 treat_var="did",
                 time_var="post",
                 unit_var="ticker",
-                x_vars=["lev", "size", "tangibility", "mb", "cash_ratio"],
+                x_vars=x_vars,
             )
 
-            # 添加中文顶刊所需的最小稳健性检验
-            runner.add_test("parallel_trends")
-            runner.add_test("placebo")
-            runner.add_test("psm")
-            runner.add_test("replace_outliers", {"pct": 1})
-            runner.add_test("sub_sample", {"year_range": [2019, 2024]})
-            runner.add_test("remove_extreme", {"n_remove": 5})
-
-            report = runner.run_all()
+            if self.explore:
+                # Deeper official suite (existing RobustnessRunner API)
+                report = runner.run_comprehensive(level="advanced")
+            else:
+                # 中文顶刊最低常用子集
+                runner.add_test("parallel_trends")
+                runner.add_test("placebo")
+                runner.add_test("psm")
+                runner.add_test("replace_outliers", {"pct": 1})
+                runner.add_test("sub_sample", {"year_range": [2019, 2024]})
+                runner.add_test("remove_extreme", {"n_remove": 5})
+                report = runner.run_all()
             self.ctx.robustness_report = report
 
             _log.info(
@@ -1242,6 +1298,22 @@ def _cli_main():
         action="store_true",
         help="Enable self-evolution loop",
     )
+    parser.add_argument(
+        "--explore",
+        action="store_true",
+        help="Deeper official empirics: more DID estimators + comprehensive robustness",
+    )
+    parser.add_argument(
+        "--allow-demo",
+        action="store_true",
+        help="Allow simulated demo panel when no local/MCP data (off by default)",
+    )
+    parser.add_argument(
+        "--panel",
+        type=str,
+        default="",
+        help="Path to local panel (csv/parquet/dta); checked before FINAI_EMPIRICAL_DATA_ROOT",
+    )
     args = parser.parse_args()
 
     print(f"\n{'='*60}")
@@ -1250,6 +1322,7 @@ def _cli_main():
     print(f"  Journal: {args.journal}")
     print(f"  Output:  {args.output}")
     print(f"  Language: {args.language}")
+    print(f"  Explore: {args.explore}")
     print(f"{'='*60}\n")
 
     pipeline = EnhancedPipeline(
@@ -1263,6 +1336,9 @@ def _cli_main():
         enable_pdf_vision=args.pdf_vision,
         enable_sandbox=True,
         enable_self_evolution=args.self_evolution,
+        explore=args.explore,
+        allow_demo=args.allow_demo,
+        panel_path=args.panel or None,
     )
 
     ctx = pipeline.run()

--- a/scripts/universal_data_fetcher.py
+++ b/scripts/universal_data_fetcher.py
@@ -845,12 +845,24 @@ class UniversalDataFetcher:
         df["_timestamp"] = datetime.now().isoformat()
         return df
 
-    def fetch_entity_list_events(self) -> pd.DataFrame:
-        """获取实体清单事件数据"""
-        result = self.fetch("entity_list")
+    def fetch_entity_list_events(
+        self, *, allow_synthetic: bool = False
+    ) -> pd.DataFrame:
+        """获取实体清单事件数据。
+
+        默认不再静默回落到 KNOWN_ENTITY_LIST；需显式 allow_synthetic=True。
+        """
+        result = self.fetch("entity_list", allow_synthetic=allow_synthetic)
         if result.data is not None and isinstance(result.data, pd.DataFrame):
             return result.data
-        return pd.DataFrame(KNOWN_ENTITY_LIST)
+        if allow_synthetic:
+            df = pd.DataFrame(KNOWN_ENTITY_LIST)
+            df["_synthetic"] = True
+            return df
+        raise SyntheticDataForbiddenError(
+            "entity_list fetch failed and allow_synthetic=False; "
+            "refusing silent KNOWN_ENTITY_LIST fallback."
+        )
 
     def fetch_macro_panel(
         self, indicators: list[str], start_year: int = 2015, end_year: int = 2025

--- a/tests/test_empirical_explore.py
+++ b/tests/test_empirical_explore.py
@@ -1,0 +1,166 @@
+"""Official empirics explore + no-silent-demo regressions."""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+
+def _tiny_did_panel() -> pd.DataFrame:
+    rows = []
+    for u in range(20):
+        treat = int(u < 10)
+        for y in (2018, 2019, 2020, 2021):
+            post = int(y >= 2020)
+            rows.append(
+                {
+                    "ticker": f"F{u:02d}",
+                    "year": y,
+                    "roa": 0.05 + 0.02 * treat * post + 0.001 * u,
+                    "lev": 0.3,
+                    "size": 21.0,
+                    "tangibility": 0.2,
+                    "mb": 1.5,
+                    "cash_ratio": 0.1,
+                    "esg_high": treat,
+                    "post": post,
+                    "did": treat * post,
+                    "sector": "tech" if u % 2 == 0 else "mfg",
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def test_load_panel_redundant_from_path(tmp_path: Path):
+    from scripts.core.empirical_explore import load_panel_redundant
+
+    p = tmp_path / "green_patent_panel.csv"
+    df = _tiny_did_panel()
+    df.to_csv(p, index=False)
+    res = load_panel_redundant(panel_path=p, topic="绿色专利")
+    assert res.ok
+    assert res.source == "path"
+    assert len(res.df) == len(df)
+
+
+def test_load_panel_redundant_from_empirical_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    from scripts.core.empirical_explore import load_panel_redundant
+
+    monkeypatch.setenv("FINAI_EMPIRICAL_DATA_ROOT", str(tmp_path))
+    (tmp_path / "firm_绿色专利.csv").write_text(
+        _tiny_did_panel().to_csv(index=False), encoding="utf-8"
+    )
+    res = load_panel_redundant(topic="企业级绿色专利 DID")
+    assert res.ok
+    assert res.source == "local_empirical"
+
+
+def test_explore_did_suite_standard_succeeds_baseline():
+    from scripts.core.empirical_explore import explore_did_suite
+    from scripts.research_framework.modern_did import ModernDiDEngine
+
+    engine = ModernDiDEngine(
+        df=_tiny_did_panel(),
+        y_var="roa",
+        treat_var="did",
+        time_var="post",
+        unit_var="ticker",
+        x_vars=["lev", "size"],
+        cluster_var="sector",
+    )
+    report = explore_did_suite(engine, level="standard", cluster_var="sector")
+    assert "did_2x2" in report.succeeded
+    assert "did_2x2" in report.results
+    # Missing sa/dCdH must not be claimed
+    assert "sa" not in report.succeeded
+
+
+def test_enhanced_pipeline_refuses_silent_demo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    from scripts.research_framework.enhanced_pipeline import EnhancedPipeline
+
+    # Explicit empty root must not fall through to repo data/sample demos
+    empty = tmp_path / "empty_root"
+    empty.mkdir()
+    monkeypatch.setenv("FINAI_EMPIRICAL_DATA_ROOT", str(empty))
+    with patch(
+        "scripts.research_framework.data_fetcher.CachedDataFetcher"
+    ) as mock_cls:
+        mock_cls.return_value.fetch_with_fallback.return_value = None
+        pipe = EnhancedPipeline(
+            topic="ESG test",
+            output_dir=tmp_path / "out",
+            allow_demo=False,
+            explore=False,
+            enable_hitl=False,
+            enable_validation_gates=False,
+            enable_latex_lint=False,
+            enable_latex_diff=False,
+            enable_pdf_vision=False,
+            enable_sandbox=False,
+        )
+        df = pipe.step1_load_data()
+    assert df.empty
+    assert pipe.ctx.step_results["step1"]["status"] == "error"
+
+
+def test_env_root_does_not_fall_through_to_repo_data(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    from scripts.core.empirical_data_root import resolve_empirical_data_root
+
+    missing = tmp_path / "no_such_root"
+    monkeypatch.setenv("FINAI_EMPIRICAL_DATA_ROOT", str(missing))
+    root = resolve_empirical_data_root()
+    assert root.source == "env"
+    assert not root.available
+    assert root.path == missing.resolve()
+
+
+def test_enhanced_pipeline_local_panel_and_explore(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    from scripts.research_framework.enhanced_pipeline import EnhancedPipeline
+
+    panel = tmp_path / "panel.csv"
+    _tiny_did_panel().to_csv(panel, index=False)
+    monkeypatch.setenv("FINAI_EMPIRICAL_DATA_ROOT", str(tmp_path / "unused"))
+
+    pipe = EnhancedPipeline(
+        topic="ESG financing",
+        output_dir=tmp_path / "out2",
+        panel_path=panel,
+        explore=True,
+        allow_demo=False,
+        enable_hitl=False,
+        enable_validation_gates=False,
+        enable_latex_lint=False,
+        enable_latex_diff=False,
+        enable_pdf_vision=False,
+        enable_sandbox=False,
+    )
+    df = pipe.step1_load_data()
+    assert not df.empty
+    assert pipe.ctx.step_results["step1"]["status"] == "ok"
+    results = pipe.step2_modern_did()
+    assert "did_2x2" in results
+    assert pipe.ctx.step_results["step2"].get("explore_level") == "explore"
+
+
+def test_entity_list_no_silent_known_fallback():
+    from scripts.universal_data_fetcher import (
+        SyntheticDataForbiddenError,
+        UniversalDataFetcher,
+    )
+
+    fetcher = UniversalDataFetcher()
+    with patch.object(fetcher, "fetch") as mock_fetch:
+        mock_fetch.return_value = MagicMock(data=None)
+        with pytest.raises(SyntheticDataForbiddenError):
+            fetcher.fetch_entity_list_events(allow_synthetic=False)
+        df = fetcher.fetch_entity_list_events(allow_synthetic=True)
+        assert not df.empty
+        assert "_synthetic" in df.columns

--- a/tests/test_empirical_integrity.py
+++ b/tests/test_empirical_integrity.py
@@ -149,7 +149,7 @@ def test_agent_host_entry_records_topic_gaps(
     assert "empirics:" in skipped or "企业级绿色专利" in skipped or "firm_green"
     assert (tmp_path / "output" / "DELIVERY.md").is_file()
     final = (tmp_path / "output" / "FINAL.md").read_text(encoding="utf-8")
-    assert "do **not** invent a parallel pipeline" in final or "parallel pipeline" in final
+    assert "enhanced_pipeline" in final or "FinAI" in final or "empirics" in final.lower()
 
 
 def test_agent_host_block_on_topic_gaps(

--- a/tests/test_enhanced_pipeline_deep_exec.py
+++ b/tests/test_enhanced_pipeline_deep_exec.py
@@ -425,11 +425,17 @@ class TestStep1LoadDataEdgeCases:
         assert isinstance(df, pd.DataFrame)
 
     def test_build_panel_from_empty_falls_back_to_demo(self):
-        p = EnhancedPipeline(topic="T")
+        # Demo fallback is opt-in only (no silent Mock)
+        p = EnhancedPipeline(topic="T", allow_demo=True)
         df = p._build_panel([])
         assert isinstance(df, pd.DataFrame)
-        # Should have fallen back to demo data (has ticker etc.)
         assert "ticker" in df.columns
+
+    def test_build_panel_from_empty_refuses_silent_demo(self):
+        p = EnhancedPipeline(topic="T", allow_demo=False)
+        df = p._build_panel([])
+        assert isinstance(df, pd.DataFrame)
+        assert df.empty
 
     def test_build_panel_unknown_type_returns_empty_df(self):
         p = EnhancedPipeline(topic="T")
@@ -437,19 +443,19 @@ class TestStep1LoadDataEdgeCases:
         assert isinstance(df, pd.DataFrame)
 
     def test_step1_load_data_returns_dataframe(self):
-        p = EnhancedPipeline(topic="T", enable_hitl=False)
+        p = EnhancedPipeline(topic="T", enable_hitl=False, allow_demo=True)
         df = p.step1_load_data()
         assert isinstance(df, pd.DataFrame)
         assert len(df) > 0
 
     def test_step1_load_data_sets_ctx_df(self):
-        p = EnhancedPipeline(topic="T", enable_hitl=False)
+        p = EnhancedPipeline(topic="T", enable_hitl=False, allow_demo=True)
         p.step1_load_data()
         assert p.ctx.df is not None
         assert isinstance(p.ctx.df, pd.DataFrame)
 
     def test_step1_load_data_records_step_result(self):
-        p = EnhancedPipeline(topic="T", enable_hitl=False)
+        p = EnhancedPipeline(topic="T", enable_hitl=False, allow_demo=True)
         p.step1_load_data()
         assert "step1" in p.ctx.step_results
         assert p.ctx.step_results["step1"]["status"] == "ok"
@@ -552,7 +558,7 @@ class TestEnhancedPipelineSummary:
         assert "Step" not in s  # no steps run yet
 
     def test_summary_with_step_results(self):
-        p = EnhancedPipeline(topic="T", enable_hitl=False)
+        p = EnhancedPipeline(topic="T", enable_hitl=False, allow_demo=True)
         p.step1_load_data()
         s = p.summary()
         assert "step1" in s.lower() or "step 1" in s.lower() or "Step 1" in s


### PR DESCRIPTION
## Summary
- Judgment: “禁止另起炉灶” alone was incomplete — freestyle was driven by thin official empirics (silent demo panel, narrow DID suite, RF fetcher skipping local root).
- Add `scripts/core/empirical_explore.py` (local panel redundancy + multi-estimator suite reusing `ModernDiDEngine`).
- `enhanced_pipeline`: local → MCP → demo only with `--allow-demo`; `--explore` runs more estimators + `run_comprehensive(advanced)`.
- `CachedDataFetcher.fetch_with_fallback` Layer-0 local root; env-set `FINAI_EMPIRICAL_DATA_ROOT` no longer falls through to repo `data/`.
- Close silent `KNOWN_ENTITY_LIST` fallback; reframe host/docs: deepen *inside* FinAI, don’t invent a second stack.

## Test plan
- [x] `pytest tests/test_empirical_explore.py tests/test_empirical_integrity.py tests/test_agent_host_entry.py`
- [ ] CI green
- [ ] Manual: `python -m scripts.research_framework.enhanced_pipeline --topic "ESG" --explore --allow-demo` (demo opt-in)
- [ ] Manual: empty `FINAI_EMPIRICAL_DATA_ROOT` + no `--allow-demo` → step1 error (no silent demo)


Made with [Cursor](https://cursor.com)