### PR TITLE
fix: parse llm_judge scores from prompt schema (#201)

### DIFF
--- a/scripts/core/benchmark.py
+++ b/scripts/core/benchmark.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import re
 import time
 from pathlib import Path
 from typing import Any
@@ -30,7 +31,67 @@ __all__ = [
     "ValidationSummary",
     "SyntheticPaperGenerator",
     "PaperWritingBench",
+    "parse_llm_judge_scores",
 ]
+
+_LLM_JUDGE_KEYS = (
+    "technical_soundness",
+    "novelty",
+    "clarity",
+    "significance",
+    "overall",
+)
+
+
+def _extract_json_object(raw: str) -> dict[str, Any]:
+    """Pull the first JSON object out of an LLM reply."""
+    text = raw.strip()
+    fenced = re.search(r"```(?:json)?\s*(.*?)\s*```", text, re.DOTALL)
+    if fenced:
+        text = fenced.group(1).strip()
+    try:
+        data = json.loads(text)
+        if isinstance(data, dict):
+            return data
+    except json.JSONDecodeError:
+        pass
+    start = text.find("{")
+    end = text.rfind("}")
+    if start == -1 or end <= start:
+        raise ValueError("judge response contains no JSON object")
+    data = json.loads(text[start : end + 1])
+    if not isinstance(data, dict):
+        raise ValueError("judge JSON is not an object")
+    return data
+
+
+def _coerce_judge_score(value: Any, key: str) -> float:
+    if isinstance(value, dict):
+        if "score" not in value:
+            raise ValueError(f"judge field {key!r} is an object without 'score'")
+        value = value["score"]
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"judge field {key!r} has unusable score {value!r}")
+    return float(value)
+
+
+def parse_llm_judge_scores(raw: str) -> dict[str, float]:
+    """Parse llm_judge_evaluate JSON.
+
+    Accepts the prompt schema (top-level dimensions) and the wrapped
+    ``{"scores": {...}}`` schema. Missing dimensions raise ValueError
+    instead of silently becoming 0.0.
+    """
+    data = _extract_json_object(raw)
+    wrapped = data.get("scores")
+    if isinstance(wrapped, dict) and any(k in wrapped for k in _LLM_JUDGE_KEYS):
+        source = wrapped
+    else:
+        source = data
+    missing = [key for key in _LLM_JUDGE_KEYS if key not in source]
+    if missing:
+        raise ValueError(f"judge response missing scores: {missing}")
+    return {key: _coerce_judge_score(source[key], key) for key in _LLM_JUDGE_KEYS}
 
 # ─── Data Models ───────────────────────────────────────────────────────────────
 
@@ -821,15 +882,13 @@ Respond ONLY with valid JSON (no markdown):
 
             try:
                 raw = reviewer._call_llm(prompt, model=judge_model, language="en")
-                data = json.loads(re.search(r"\{.*\}", raw, re.DOTALL).group())
-                s = data.get("scores", {})
-
-                soundness = float(s.get("technical_soundness", {}).get("score", 0))
-                novelty = float(s.get("novelty", {}).get("score", 0))
-                clarity = float(s.get("clarity", {}).get("score", 0))
-                significance = float(s.get("significance", {}).get("score", 0))
-                overall = float(s.get("overall", {}).get("score", 0))
-                llm_mean = np.mean([soundness, novelty, clarity, significance, overall])
+                parsed = parse_llm_judge_scores(raw)
+                soundness = parsed["technical_soundness"]
+                novelty = parsed["novelty"]
+                clarity = parsed["clarity"]
+                significance = parsed["significance"]
+                overall = parsed["overall"]
+                llm_mean = float(np.mean([soundness, novelty, clarity, significance, overall]))
 
                 # Scale halt_score from [0,1] to [1,10] for comparison
                 halt_scaled = halt_score * 9 + 1

--- a/tests/test_benchmark_unit.py
+++ b/tests/test_benchmark_unit.py
@@ -17,6 +17,7 @@ try:
         ValidationSummary,
         SyntheticPaperGenerator,
         PaperWritingBench,
+        parse_llm_judge_scores,
     )
 except Exception as _exc:
     pytest.skip(f"benchmark not importable: {_exc}", allow_module_level=True)
@@ -728,6 +729,123 @@ class TestPaperWritingBenchLLMJudge:
         ]
         df = bench.llm_judge_evaluate(papers)
         assert len(df) == 3
+
+    def test_llm_judge_evaluate_reads_prompt_schema(self):
+        """Instruction-following top-level scores must not collapse to 0.0 (#201)."""
+        from unittest.mock import MagicMock, patch
+
+        bench = PaperWritingBench()
+        papers = [{"paper_id": "p1", "domain": "empirical_paper", "halt_score": 0.8, "text": "x"}]
+        payload = (
+            '{"technical_soundness": {"score": 7.0, "reasoning": "ok"},'
+            ' "novelty": {"score": 8.0, "reasoning": "ok"},'
+            ' "clarity": {"score": 6.0, "reasoning": "ok"},'
+            ' "significance": {"score": 7.5, "reasoning": "ok"},'
+            ' "overall": {"score": 7.0, "reasoning": "ok"}}'
+        )
+        mock_rev = MagicMock()
+        mock_rev._call_llm.return_value = payload
+        with patch("scripts.core.reviewer.LLMReviewer", return_value=mock_rev):
+            df = bench.llm_judge_evaluate(papers)
+        row = df.iloc[0]
+        assert row["llm_soundness"] == 7.0
+        assert row["llm_novelty"] == 8.0
+        assert row["llm_clarity"] == 6.0
+        assert row["llm_significance"] == 7.5
+        assert row["llm_overall"] == 7.0
+        assert abs(row["llm_mean"] - 7.1) < 1e-9
+        assert abs(row["score_diff"] - 1.1) < 1e-9
+
+    def test_llm_judge_evaluate_incomplete_json_uses_fallback_not_zeros(self):
+        """Missing dimensions must not be recorded as successful 0.0 scores."""
+        from unittest.mock import MagicMock, patch
+
+        bench = PaperWritingBench()
+        papers = [{"paper_id": "p1", "domain": "empirical_paper", "halt_score": 0.8, "text": "x"}]
+        mock_rev = MagicMock()
+        mock_rev._call_llm.return_value = '{"novelty": {"score": 9.0, "reasoning": "only one"}}'
+        with patch("scripts.core.reviewer.LLMReviewer", return_value=mock_rev):
+            df = bench.llm_judge_evaluate(papers)
+        row = df.iloc[0]
+        # halt_score 0.8 → scaled 8.2 fallback, not parsed 0.0
+        assert row["llm_mean"] == 8.2
+        assert row["score_diff"] == 0.0
+        assert bool(row["agreement"]) is True
+
+
+class TestParseLlmJudgeScores:
+    """#201: prompt schema and wrapped schema must both parse."""
+
+    _PROMPT = {
+        "technical_soundness": {"score": 7.0, "reasoning": "brief"},
+        "novelty": {"score": 8.0, "reasoning": "brief"},
+        "clarity": {"score": 6.0, "reasoning": "brief"},
+        "significance": {"score": 7.5, "reasoning": "brief"},
+        "overall": {"score": 7.0, "reasoning": "brief"},
+    }
+
+    def test_prompt_schema_top_level(self):
+        import json
+
+        scores = parse_llm_judge_scores(json.dumps(self._PROMPT))
+        assert scores == {
+            "technical_soundness": 7.0,
+            "novelty": 8.0,
+            "clarity": 6.0,
+            "significance": 7.5,
+            "overall": 7.0,
+        }
+
+    def test_wrapped_scores_schema(self):
+        import json
+
+        scores = parse_llm_judge_scores(json.dumps({"scores": self._PROMPT}))
+        assert scores["novelty"] == 8.0
+        assert scores["overall"] == 7.0
+
+    def test_markdown_fence(self):
+        import json
+
+        raw = "Here you go:\n```json\n" + json.dumps(self._PROMPT) + "\n```\n"
+        scores = parse_llm_judge_scores(raw)
+        assert scores["clarity"] == 6.0
+
+    def test_bare_numeric_scores(self):
+        raw = (
+            '{"technical_soundness": 7, "novelty": 8, "clarity": 6,'
+            ' "significance": 7.5, "overall": 7}'
+        )
+        scores = parse_llm_judge_scores(raw)
+        assert scores["significance"] == 7.5
+
+    def test_empty_scores_wrapper_falls_back_to_top_level(self):
+        import json
+
+        payload = {"scores": {}, **self._PROMPT}
+        scores = parse_llm_judge_scores(json.dumps(payload))
+        assert scores["novelty"] == 8.0
+
+    def test_missing_dimension_raises(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="missing scores"):
+            parse_llm_judge_scores('{"novelty": {"score": 8.0, "reasoning": "x"}}')
+
+    def test_no_json_raises(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="no JSON object"):
+            parse_llm_judge_scores("not json at all")
+
+    def test_old_parser_would_have_zeroed_prompt_schema(self):
+        """Document the #201 failure mode against the new parser."""
+        import json
+
+        data = json.loads(json.dumps(self._PROMPT))
+        old = data.get("scores", {})
+        assert old == {}  # old path
+        new = parse_llm_judge_scores(json.dumps(self._PROMPT))
+        assert new["technical_soundness"] == 7.0
 
 
 class TestPaperWritingBenchPrintRuleBreakdown:


### PR DESCRIPTION
## Summary
- Fixes #201: `llm_judge_evaluate` asked for top-level dimension objects, but parsed `data["scores"]` and was missing `import re`. Instruction-following JSON became silent `0.0`.
- Parser now accepts the prompt schema and the wrapped `scores` schema; missing dimensions raise instead of recording fake zeros.
- Added regression tests that reproduce the old `get("scores", {})` zero-out and check the evaluate path with a mocked reviewer.

## Test plan
- [x] Reproduced old parser → all scores `0.0`
- [x] `pytest tests/test_benchmark_unit.py::TestParseLlmJudgeScores tests/test_benchmark_unit.py::TestPaperWritingBenchLLMJudge` (14 passed, twice; 10 passed after rebase)
- [x] `ruff check` on the two changed files
- [ ] CI on this PR


Made with [Cursor](https://cursor.com)