### PR TITLE
ci: bump CodeQL init and analyze together to 4.37.8

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,9 +22,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
+        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           languages: python
 
       - name: Analyze
-        uses: github/codeql-action/analyze@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
+        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8


### PR DESCRIPTION
## Summary
- Supersedes #199 and #200. Dependabot bumped `codeql-action/init` and `codeql-action/analyze` in separate PRs; each fails with `Loaded a configuration file for version '4.37.5', but running version '4.37.8'`.
- Pins both steps to the same `v4.37.8` SHA (`db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28`).

## Test plan
- [ ] CodeQL Analyze Python on this PR
- [ ] Other required CI (should be unaffected)


Made with [Cursor](https://cursor.com)