### PR TITLE
feat: run the gold-slot tables; repair the empirics→writing hand-off

### DIFF
--- a/.agents/skills/fin-experiment-design/SKILL.md
+++ b/.agents/skills/fin-experiment-design/SKILL.md
@@ -33,6 +33,12 @@ python -m scripts.core.empirical_package scaffold --mode core --unit firm
 python -m scripts.core.empirical_package audit output/fin-refinement/empirical_package.json
 ```
 
+实证轨跑一遍就能把能算的格填上（结构事实 / 逐步 / 更紧 / 样本流；机制须自己点名渠道）：
+
+```bash
+python -m scripts.research_framework.enhanced_pipeline --topic "..." --mechanism 渠道列名
+```
+
 `empirical_package.json` 最低要求：`y_construct` / `x_construct`、每件控制的 `variable_jobs`（中文 `table_row` + 接到本题 Y 的 `job` + 非贴纸 `basis`）、黄金八格（缺格写 `dropped` 理由）、政策 DID 还要独立于电池的 `mechanism_channels` 与 `figure_gate`。政策 DID 不得 `dropped: mechanism`。交稿是合取：主栏显著 ∧ 控制有职务 ∧ 活机制表 ∧ 图干净。
 
 ## 前置条件

--- a/.cursor/skills/fin-experiment-design/SKILL.md
+++ b/.cursor/skills/fin-experiment-design/SKILL.md
@@ -33,6 +33,12 @@ python -m scripts.core.empirical_package scaffold --mode core --unit firm
 python -m scripts.core.empirical_package audit output/fin-refinement/empirical_package.json
 ```
 
+实证轨跑一遍就能把能算的格填上（结构事实 / 逐步 / 更紧 / 样本流；机制须自己点名渠道）：
+
+```bash
+python -m scripts.research_framework.enhanced_pipeline --topic "..." --mechanism 渠道列名
+```
+
 `empirical_package.json` 最低要求：`y_construct` / `x_construct`、每件控制的 `variable_jobs`（中文 `table_row` + 接到本题 Y 的 `job` + 非贴纸 `basis`）、黄金八格（缺格写 `dropped` 理由）、政策 DID 还要独立于电池的 `mechanism_channels` 与 `figure_gate`。政策 DID 不得 `dropped: mechanism`。交稿是合取：主栏显著 ∧ 控制有职务 ∧ 活机制表 ∧ 图干净。
 
 ## 前置条件

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,10 @@ Stage 4: Empirical Design    → scaffold: pipeline.py --mode design
 Stage 5: Data Acquisition    → scripts/universal_data_fetcher.py
 Stage 6: Analysis            → python -m scripts.research_framework.enhanced_pipeline
                                or import scripts.research_framework.modern_did
-                               (writes output/empirical_package.json; missing slots stay dropped)
+                               step2b runs the gold slots (structure facts / stepwise /
+                               tighter / sample flow / T→M with --mechanism M ...),
+                               writes GOLD_TABLES.md + empirical_package.json;
+                               slots that did not run stay dropped with a reason
 Stage 6.5 Write-gate         → python -m scripts.core.empirical_package audit <package.json>
 Stage 7: Paper Draft         → scripts/agent_pipeline.py / report_generator.py  【写作轨】
 Stage 8: Review              → scripts/core/llm_reviewer.py
@@ -122,11 +125,11 @@ HITL protocol (`AgentOrchestrator` / `AgentPipeline`):
 | Run full pipeline | `python scripts/agent_pipeline.py --topic "..." --use-hitl` |
 | Agent-host batch (fail-closed) | `python scripts/agent_host_entry.py --topic "..."` |
 | Generate paper draft | `python scripts/research_framework/report_generator.py --outline FILE.md` |
-| Run empirics (modern DID) | `python -m scripts.research_framework.enhanced_pipeline --topic "..."` or `from scripts.research_framework import modern_did` |
+| Run empirics (modern DID) | `python -m scripts.research_framework.enhanced_pipeline --topic "..." [--mechanism M1 M2]` or `from scripts.research_framework import modern_did` |
 | Audit empirical package / write-gate | `python -m scripts.core.empirical_package audit output/empirical_package.json` |
 | List journal templates | `python scripts/journal_template.py --list` |
 | List / register MCP servers | `python scripts/register_mcp_servers.py --list` / `--profile academic --prune` |
-| Verify project integrity | `python scripts/audit_guard.py` (25/25 checks) |
+| Verify project integrity | `python scripts/audit_guard.py` (26/26 checks) |
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,7 @@ pytest tests/ -v
 > - `user-newsapi` — NewsAPI Key（免费注册有限额）
 > - `user-yfinance` / `user-sec-edgar` — 免费，无需 Key
 
-### 计量方法（约58种独立实现，JF/JFE/RFS 标准）
+### 计量方法（约59种独立实现，JF/JFE/RFS 标准）
 
 > **重要说明**：以下方法中，标注 🔗 的依赖 `linearmodels`、`diff-in-diff2` 等第三方包；标注 ⭐ 的为独立 Python 实现。
 > 数量为近似值，因部分估计器（如 TWFE × 3 种 SE × bootstrap 变体）存在重复计数。
@@ -234,7 +234,8 @@ output/                           # 输出目录
 | `scripts/register_mcp_servers.py --list` | 列出 `{{MCP_COUNT}}` 个 MCP 服务器注册状态（首次必须跑）|
 | `scripts/register_mcp_servers.py` | 一键注册所有 MCP 到 `~/.cursor/mcp.json` |
 | `scripts/research_framework/pipeline.py` | 实证 demo TWFE + design scaffold（非写作轨）|
-| `scripts/research_framework/enhanced_pipeline.py` | 实证生产入口（现代 DID；写出 `empirical_package.json`）|
+| `scripts/research_framework/enhanced_pipeline.py` | 实证生产入口（现代 DID；`--mechanism` 指定渠道；写出 `GOLD_TABLES.md` + `empirical_package.json`）|
+| `scripts/research_framework/gold_tables.py` | 黄金八格实跑表（结构事实 / 逐步 / 更紧 / 样本流 / 处理→M）|
 | `scripts/core/empirical_package.py` | 实证包写稿门（黄金八格 / 控制职务 / 机制分列 / 图门）|
 | `scripts/research_framework/modern_did.py` | 现代 DID 库（import，无独立 CLI）|
 | `scripts/research_framework/fin_charts.py` | 专业金融图表 |

--- a/README_EN.md
+++ b/README_EN.md
@@ -122,7 +122,7 @@ coefficients, citations, or statistical claims. Regenerate it with
 
 ### 🏗 Engineering Quality
 
-- ✅ 675 test files, 7 CI jobs, 3-OS matrix (Ubuntu + macOS + Windows)
+- ✅ 677 test files, 7 CI jobs, 3-OS matrix (Ubuntu + macOS + Windows)
 - ✅ Coverage report, codecov badge
 - ✅ Pre-commit hooks (ruff + mypy + codespell + commitlint)
 - ✅ Dependabot (pip + GitHub Actions)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -19,7 +19,10 @@ FinAI is **two cooperating tracks**, not one fused DAG. Writing does not call mo
 
 Hand-off: finish empirics → feed tables/figures into writing (`report_generator` / `agent_pipeline`). Do not treat `pipeline.py` as “the research entry.”
 
-The hand-off carries a contract, not just tables: `enhanced_pipeline` writes
+The hand-off carries a contract, not just tables: `enhanced_pipeline` step2b runs
+the gold slots (`gold_tables.py` — structure facts, stepwise ladder, tighter
+comparison, sample flow, and treatment→M for every channel named via
+`--mechanism`), emits `GOLD_TABLES.md`, and writes
 `<output_dir>/empirical_package.json` (gold slots, control jobs, T→M channels,
 figure gate; whatever it did not run stays `dropped`). The writing pre-gate reads
 it (`scripts/core/empirical_package.py`) and blocks the draft unless the main

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -19,6 +19,14 @@ FinAI is **two cooperating tracks**, not one fused DAG. Writing does not call mo
 
 Hand-off: finish empirics → feed tables/figures into writing (`report_generator` / `agent_pipeline`). Do not treat `pipeline.py` as “the research entry.”
 
+The hand-off carries a contract, not just tables: `enhanced_pipeline` writes
+`<output_dir>/empirical_package.json` (gold slots, control jobs, T→M channels,
+figure gate; whatever it did not run stays `dropped`). The writing pre-gate reads
+it (`scripts/core/empirical_package.py`) and blocks the draft unless the main
+column is significant, controls carry jobs tied to *this* Y, a live mechanism
+table exists, and the genre's fourth piece holds. No package → writing-only
+track, gate soft-skips.
+
 > **CLI 入口 (写作轨)**
 >
 > `AgentOrchestrator` / `MultiAgentOrchestrator` 是**库级 API**, 用户应通过以下 CLI 入口调用:

--- a/scripts/PROJECT_NUMBERS.json
+++ b/scripts/PROJECT_NUMBERS.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./project_numbers.schema.json",
   "_comment": "Single Source of Truth for all project metric numbers. All documentation MUST reference these values. Update this file via `python scripts/count_assets.py --sync-ssot`, not by hand. Manually maintained numbers historically drift; auto-generation from disk eliminates the root cause.",
-  "last_verified": "2026-08-09",
+  "last_verified": "2026-08-31",
   "verified_by": "scripts/count_assets.py --sync-ssot",
   "generation_command": "python scripts/count_assets.py --sync-ssot",
   "_manual_overrides": {
@@ -48,11 +48,11 @@
     ]
   },
   "econometrics": {
-    "total_method_modules": 58,
+    "total_method_modules": 59,
     "test_coverage": {
-      "modules_with_tests": 56,
-      "modules_total": 58,
-      "percent": 96.55
+      "modules_with_tests": 57,
+      "modules_total": 59,
+      "percent": 96.61
     },
     "zero_test_modules": [
       "arch_diagram_demos",
@@ -105,8 +105,8 @@
     "note": "30 = unique keys in JOURNAL_METADATA dict. TEMPLATES dict has 44 entries with legacy aliases merged into 30 unique templates (see scripts/journal_template.py)."
   },
   "testing": {
-    "test_files": 675,
-    "test_functions": 12789,
+    "test_files": 677,
+    "test_functions": 12823,
     "numerical_correctness_tests": 9,
     "ci_coverage_gate": 60,
     "ci_coverage_target": 65,

--- a/scripts/SCRIPTS_INDEX.md
+++ b/scripts/SCRIPTS_INDEX.md
@@ -10,12 +10,12 @@
 | 分类 | 数量 | 说明 |
 |------|------|------|
 | 🚀 Entry Points (`scripts/*.py`) | 106 | 顶级入口脚本（含 CLI） |
-| 📦 Core Modules (`scripts/core/`) | 110 | 核心库（被其他模块导入）|
+| 📦 Core Modules (`scripts/core/`) | 111 | 核心库（被其他模块导入）|
 | 📊 Research Framework (`scripts/research_framework/`) | 59 | 计量方法模块 |
 | 🧭 Research Directions (`scripts/research_directions/`) | 15 | 研究方向领域 |
-| 🧪 Tests (`tests/`) | 677 | 测试文件 |
+| 🧪 Tests (`tests/`) | 678 | 测试文件 |
 | 🔌 MCP Servers (`mcp_servers/user_*/`) | 43 | MCP 数据源 |
-| **合计（仅 Python 文件）** | **967** | 不含 MCP / docs / tests fixtures |
+| **合计（仅 Python 文件）** | **969** | 不含 MCP / docs / tests fixtures |
 
 > 自动生成于 2026-08-09
 ---

--- a/scripts/SCRIPTS_INDEX.md
+++ b/scripts/SCRIPTS_INDEX.md
@@ -11,13 +11,13 @@
 |------|------|------|
 | 🚀 Entry Points (`scripts/*.py`) | 106 | 顶级入口脚本（含 CLI） |
 | 📦 Core Modules (`scripts/core/`) | 111 | 核心库（被其他模块导入）|
-| 📊 Research Framework (`scripts/research_framework/`) | 59 | 计量方法模块 |
+| 📊 Research Framework (`scripts/research_framework/`) | 60 | 计量方法模块 |
 | 🧭 Research Directions (`scripts/research_directions/`) | 15 | 研究方向领域 |
-| 🧪 Tests (`tests/`) | 678 | 测试文件 |
+| 🧪 Tests (`tests/`) | 679 | 测试文件 |
 | 🔌 MCP Servers (`mcp_servers/user_*/`) | 43 | MCP 数据源 |
-| **合计（仅 Python 文件）** | **969** | 不含 MCP / docs / tests fixtures |
+| **合计（仅 Python 文件）** | **971** | 不含 MCP / docs / tests fixtures |
 
-> 自动生成于 2026-08-09
+> 自动生成于 2026-08-31
 ---
 
 ## 一、Entry Points · 用户入口
@@ -57,6 +57,7 @@
 || `empirical_agent.py` | `python scripts/empirical_agent.py` | 智能实证分析 Agent（自动诊断 + 调参） |
 || `empirical_advisor.py` | via class | 实证分析顾问（5级调参策略，被 `empirical_agent.py` 使用） |
 || `core/empirical_package.py` | `python -m scripts.core.empirical_package audit FILE` | 实证包契约 + 写稿合取门（黄金八格 / 控制职务 / 机制分列 / 图门） |
+|| `research_framework/gold_tables.py` | via class | 黄金八格实跑表（结构事实 / 逐步 / 更紧 / 样本流 / 处理→M） |
 || `econometrics_extended.py` | `python scripts/econometrics_extended.py` | 核心计量引擎（DID / OLS / PSM / GMM / Heckman 等） |
 
 ### 1.4 金融分析
@@ -219,4 +220,4 @@ report_*.py           # 报告生成（小写下划线）
 
 ---
 
-*本索引由 `scripts/SCRIPTS_INDEX.md` 维护，最后更新: 2026-08-09（自动对账）
+*本索引由 `scripts/SCRIPTS_INDEX.md` 维护，最后更新: 2026-08-31（自动对账）

--- a/scripts/agent_pipeline.py
+++ b/scripts/agent_pipeline.py
@@ -1575,7 +1575,10 @@ class AgentPipeline:
             from scripts.core.empirical_package import check_empirical_package
 
             out_raw = getattr(self.config, "output_dir", None)
+            # Must cover where enhanced_pipeline drops the package, or the
+            # Stage 6 → Stage 7 hand-off silently skips this gate.
             search_dirs = [
+                Path("output"),
                 Path("output/fin-refinement"),
                 Path("output/fin-experiments"),
             ]

--- a/scripts/audit_guard.py
+++ b/scripts/audit_guard.py
@@ -1637,6 +1637,74 @@ def check_17_no_research_integrity_anti_patterns() -> CheckResult:
 # ────────────────────────────────────────────────────────────────────
 
 
+def _check_empirical_package_wiring() -> CheckResult:
+    """2026-08-31: the write-gate only protects anything if both ends match.
+
+    Three links, all of which have silently broken before:
+      1. enhanced_pipeline writes ``<output_dir>/empirical_package.json``
+      2. the writing pre-gate searches the dir the empirics track defaults to
+      3. agent_pipeline actually calls the pre-gate
+    """
+    root = Path(__file__).parent.parent
+    gate = root / "scripts" / "core" / "empirical_package.py"
+    emp = root / "scripts" / "research_framework" / "enhanced_pipeline.py"
+    writer = root / "scripts" / "agent_pipeline.py"
+    evidence: list[str] = []
+
+    missing = [str(p.relative_to(root)) for p in (gate, emp, writer) if not p.exists()]
+    if missing:
+        return CheckResult(
+            passed=False,
+            expected="empirical_package.py + enhanced_pipeline.py + agent_pipeline.py",
+            actual=f"missing: {', '.join(missing)}",
+            evidence=[],
+        )
+
+    emp_src = emp.read_text(encoding="utf-8")
+    writer_src = writer.read_text(encoding="utf-8")
+
+    emits = (
+        "def _write_empirical_package" in emp_src
+        and "self._write_empirical_package()" in emp_src
+        and 'self.output_dir / "empirical_package.json"' in emp_src
+    )
+    if emits:
+        evidence.append("enhanced_pipeline writes <output_dir>/empirical_package.json")
+
+    # The gate must search the empirics default output dir ("output/").
+    # Scope to the pre-gate body: agent_pipeline.py mentions Path("output")
+    # elsewhere, and a whole-file grep would pass even with the search broken.
+    start = writer_src.find("def _run_writing_pre_gate")
+    end = writer_src.find("\n    def ", start + 1) if start >= 0 else -1
+    gate_body = writer_src[start : end if end != -1 else len(writer_src)] if start >= 0 else ""
+    searches_default = (
+        "check_empirical_package" in gate_body and 'Path("output")' in gate_body
+    )
+    if searches_default:
+        evidence.append('writing pre-gate searches Path("output")')
+
+    called = writer_src.count("_run_writing_pre_gate") >= 2  # def + call site
+    if called:
+        evidence.append("agent_pipeline calls _run_writing_pre_gate")
+
+    gold = root / "scripts" / "research_framework" / "gold_tables.py"
+    has_gold = (
+        gold.exists()
+        and "def step2b_gold_tables" in emp_src
+        and "self.step2b_gold_tables()" in emp_src
+    )
+    if has_gold:
+        evidence.append("gold-slot tables run in step2b")
+
+    ok = emits and searches_default and called and has_gold
+    return CheckResult(
+        passed=ok,
+        expected="emit + search-path + call-site + gold tables all wired",
+        actual=f"{len(evidence)}/4 links present",
+        evidence=evidence,
+    )
+
+
 CHECKS: list[AuditCheck] = [
     AuditCheck(
         1,
@@ -1812,6 +1880,19 @@ CHECKS: list[AuditCheck] = [
         "downstream pipeline treats it as a real result, producing empty "
         "LaTeX tables without warning — academic integrity risk.",
         lambda: _check_data_warning_notifier(),
+    ),
+    # 2026-08-31: empirical package write-gate must stay wired end to end
+    AuditCheck(
+        26,
+        "Empirical package write-gate is wired across both tracks",
+        "Verify empirics emit output/empirical_package.json, the writing "
+        "pre-gate searches that directory, and the gate is actually called "
+        "from the pipeline. Failure mode being defended against: a CI "
+        "workaround narrows the search path (or the emit step is dropped), "
+        "so a policy-DID draft is written with no mechanism table, an "
+        "insignificant main column, or a dirty event-study figure — and "
+        "nothing complains.",
+        lambda: _check_empirical_package_wiring(),
     ),
 ]  # noqa: E501
 

--- a/scripts/core/empirical_package.py
+++ b/scripts/core/empirical_package.py
@@ -374,12 +374,20 @@ def write_gate(pkg: Mapping[str, Any]) -> list[PackageFinding]:
         cross0 = int(fig.get("event_post_cross0_n") or 0)
         outside = fig.get("placebo_true_outside_mass")
         event0_job = str(fig.get("event0_job") or "").strip()
-        if post_n <= 0 or cross0 > 0:
+        if post_n <= 0:
             findings.append(
                 PackageFinding(
                     "error",
                     "figure_gate",
-                    "政策 DID 事件图处理后多数 CI 不得跨 0；TWFE 显著但图不干净不能交",
+                    "事件图没有处理后期数（event_post_n=0）：时间轴用年份而非 0/1 post 重跑",
+                )
+            )
+        elif cross0 > 0:
+            findings.append(
+                PackageFinding(
+                    "error",
+                    "figure_gate",
+                    f"事件图处理后有 {cross0}/{post_n} 个 CI 跨 0；TWFE 显著但图不干净不能交",
                 )
             )
         if outside is not True:
@@ -547,51 +555,125 @@ def check_empirical_package(
     )
 
 
-def package_from_pipeline_ctx(ctx: Any) -> dict[str, Any]:
-    """Honest scaffold from EnhancedPipeline context. Missing slots stay dropped."""
-    results = getattr(ctx, "modern_did_results", None) or {}
-    topic = str(getattr(ctx, "topic", "") or "")
-    main_p = None
-    main_col = ""
-    for key, val in results.items() if isinstance(results, Mapping) else []:
-        if not isinstance(val, Mapping):
-            continue
-        for pk in ("pval", "p", "pvalue", "p_value"):
-            if pk in val:
-                try:
-                    main_p = float(val[pk])
-                    main_col = str(key)
-                except (TypeError, ValueError):
-                    continue
-                break
-        if main_col:
-            break
+_DROP_REASONS: dict[str, str] = {
+    "desc": "流水线未生成描述统计（面板为空或未跑 step2b）",
+    "facts_before_reg": "未跑回归前结构事实表",
+    "baseline_stepwise": "未跑逐步加信息的基准表",
+    "tighter_compare": "未跑 within / 更局部 FE 的更紧比较",
+    "robust_matrix": "未跑稳健性矩阵",
+    "mechanism": "未点名 M：用 --mechanism 指定渠道后重跑，写稿前必须补机制表",
+    "sample_flow": "未记录逐步流失 n",
+    "parallel_trends": "未跑平行趋势/事件研究",
+    "placebo": "未跑随机安慰剂",
+    "exclusive": "未跑排他政策",
+    "psm": "未跑 PSM；有排他金融政策时可保留此 dropped",
+    "hetero": "未跑两条异质",
+}
 
-    ran_baseline = bool(results)
-    robust = getattr(ctx, "robustness_report", None)
-    ran_robust = robust is not None and bool(getattr(robust, "__len__", lambda: True)())
+
+def _robustness_tests(ctx: Any) -> list[Any]:
+    report = getattr(ctx, "robustness_report", None)
+    if report is None:
+        return []
+    tests = getattr(report, "tests", None)
+    if isinstance(tests, list):
+        return tests
+    return list(report) if isinstance(report, list) else []
+
+
+def _find_test(tests: Iterable[Any], *needles: str) -> Any | None:
+    for test in tests:
+        name = f"{getattr(test, 'test_name', '')} {getattr(test, 'test_type', '')}".lower()
+        if any(n in name for n in needles):
+            return test
+    return None
+
+
+def package_from_pipeline_ctx(ctx: Any) -> dict[str, Any]:
+    """Build the package from what the pipeline actually ran.
+
+    Slots backed by a real table are filled; everything else stays ``dropped``
+    with a reason. Control ``job`` / ``basis`` and ``mechanism_theory`` are
+    left empty on purpose — generated text there would be the sticker the
+    contract rejects, so the gate keeps asking the human for them.
+    """
     pkg = empty_package(mode="core", unit="firm")
-    pkg["y_construct"] = topic or "未点名 Y"
-    pkg["x_construct"] = "处理（流水线未点名官方名单/时点）"
-    pkg["main_col"] = main_col or "did"
-    pkg["main_p"] = main_p
-    pkg["slots"]["baseline_stepwise"] = "enhanced_pipeline.modern_did" if ran_baseline else ""
-    pkg["slots"]["robust_matrix"] = "enhanced_pipeline.robustness_runner" if ran_robust else ""
-    pkg["slots"]["parallel_trends"] = str(
-        getattr(ctx, "parallel_trends_method", "") or "event_study"
+    topic = str(getattr(ctx, "topic", "") or "")
+    tables = getattr(ctx, "gold_tables", None)
+    tests = _robustness_tests(ctx)
+    results = getattr(ctx, "modern_did_results", None) or {}
+
+    pkg["y_construct"] = getattr(tables, "y_var", "") or topic or "未点名 Y"
+    pkg["x_construct"] = (
+        f"处理组 {getattr(tables, 'treat_var', '')} × 政策后"
+        if tables is not None
+        else "处理（流水线未点名官方名单/时点）"
     )
+
+    # ── slots the gold-table run can fill ───────────────────────────────
+    if tables is not None:
+        pkg["slots"].update(tables.to_slots())
+        battery = list(getattr(tables, "battery", []) or [])
+        pkg["battery"] = battery
+        # Skeleton rows only: name + printed row. job/basis stay for the human.
+        pkg["variable_jobs"] = [
+            {"name": name, "table_row": "", "construct": "", "job": "", "basis": ""}
+            for name in battery
+        ]
+        main = tables.main_column
+        if main is not None:
+            pkg["main_col"] = main.label
+            pkg["main_p"] = main.pval
+        channels = [m.channel for m in getattr(tables, "mechanism", []) or []]
+        if channels:
+            pkg["mechanism_channels"] = channels
+            pkg["mechanism_methods"] = ["did_on_m"]
+
+    if pkg["main_p"] is None:
+        for key, val in results.items() if isinstance(results, Mapping) else []:
+            if not isinstance(val, Mapping):
+                continue
+            for pk in ("pval", "p", "pvalue", "p_value"):
+                if pk in val:
+                    try:
+                        pkg["main_p"] = float(val[pk])
+                        pkg["main_col"] = pkg["main_col"] or str(key)
+                    except (TypeError, ValueError):
+                        continue
+                    break
+            if pkg["main_p"] is not None:
+                break
+
+    # ── slots the robustness runner can fill ────────────────────────────
+    if tests:
+        pkg["slots"]["robust_matrix"] = f"稳健性矩阵（{len(tests)} 项）"
+    for slot, needles in (
+        ("parallel_trends", ("parallel", "trend")),
+        ("placebo", ("placebo",)),
+        ("psm", ("psm", "propensity")),
+        ("hetero", ("hetero", "异质")),
+    ):
+        test = _find_test(tests, *needles)
+        if test is not None:
+            pkg["slots"][slot] = str(getattr(test, "test_name", slot))
+
+    # ── figure gate, measured rather than asserted ──────────────────────
+    placebo = _find_test(tests, "placebo")
+    placebo_p = getattr(placebo, "did_pval", None) if placebo is not None else None
+    event_rows = results.get("event_study_data") if isinstance(results, Mapping) else None
+    if isinstance(event_rows, list) or placebo_p is not None:
+        from scripts.research_framework.gold_tables import figure_gate_from_event_study
+
+        pkg["figure_gate"] = figure_gate_from_event_study(
+            event_rows if isinstance(event_rows, list) else [],
+            placebo_tail_p=placebo_p,
+        )
+
     pkg["dropped"] = [
-        {"slot": "desc", "reason": "enhanced_pipeline 未生成变量定义表，须设计轨补全"},
-        {"slot": "facts_before_reg", "reason": "流水线未跑回归前结构事实表"},
-        {"slot": "tighter_compare", "reason": "未自动跑 within / 更局部 FE 梯子"},
-        {"slot": "mechanism", "reason": "流水线未估计处理→独立 M；写稿前必须补机制表"},
-        {"slot": "sample_flow", "reason": "未记录逐步流失 n"},
-        {"slot": "placebo", "reason": "未跑随机安慰剂密度"},
-        {"slot": "exclusive", "reason": "未跑排他政策"},
-        {"slot": "psm", "reason": "未跑 PSM；有排他金融政策时可保留此 dropped"},
-        {"slot": "hetero", "reason": "未跑两条异质"},
+        {"slot": name, "reason": _DROP_REASONS.get(name, "未跑")}
+        for name in (*GOLD_SLOTS, *CORE_OVERLAY_SLOTS)
+        if not _slot_filled(pkg["slots"], name)
     ]
-    # Honest: core still fails mechanism_required — that is the point.
     return pkg
 
 

--- a/scripts/research_framework/enhanced_pipeline.py
+++ b/scripts/research_framework/enhanced_pipeline.py
@@ -45,7 +45,7 @@ import logging
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Sequence
 
 import pandas as pd
 
@@ -76,6 +76,9 @@ class PipelineContext:
 
     # Modern DID Results
     modern_did_results: dict[str, Any] = field(default_factory=dict)
+
+    # Gold-slot tables (structure facts / stepwise / tighter / sample flow / T→M)
+    gold_tables: Any = None
 
     # Robustness
     robustness_report: Any = None
@@ -153,6 +156,7 @@ class EnhancedPipeline:
         explore: bool = False,
         allow_demo: bool = False,
         panel_path: str | Path | None = None,
+        mechanism_vars: Sequence[str] = (),
         **kwargs,
     ):
         self.topic = topic
@@ -172,6 +176,8 @@ class EnhancedPipeline:
         self.explore = bool(explore or kwargs.get("explore", False))
         self.allow_demo = bool(allow_demo or kwargs.get("allow_demo", False))
         self.panel_path = panel_path or kwargs.get("panel_path")
+        # Named mechanism channels. Never auto-invented: the caller names M.
+        self.mechanism_vars = list(mechanism_vars or kwargs.get("mechanism_vars") or ())
         self.enable_hitl = enable_hitl
         self.hitl_timeout = hitl_timeout
         # 审批通过回调：签名 on_gate_approved(stage_name: str, ctx: PipelineContext)
@@ -740,7 +746,7 @@ class EnhancedPipeline:
             from scripts.research_framework.report_generator import ReportGenerator
             from scripts.research_framework.base import ProvenanceTracker
 
-            tracker = ProvenanceTracker(output_dir=str(self.output_dir))
+            tracker = ProvenanceTracker()
 
             gen = ReportGenerator(
                 output_dir=str(self.output_dir),
@@ -1060,6 +1066,9 @@ class EnhancedPipeline:
             # 审批通过 → 推送 DID 策略可视化（平行趋势图等）
             self._notify_gate_approved("step2_did_strategy", gate_result.get("feedback", "") if gate_result else "")
 
+        # Step 2b: 黄金八格实跑表（结构事实 / 逐步 / 更紧 / 样本流 / T→M）
+        self.step2b_gold_tables()
+
         # Step 3: 稳健性检验
         self.step3_robustness()
         _log.info("[Step 3] 稳健性检验完成")
@@ -1137,6 +1146,66 @@ class EnhancedPipeline:
         _log.info(f"=" * 60)
 
         return self.ctx
+
+    _GROUP_CANDIDATES = ("esg_high", "treat", "treated", "treatment", "group")
+
+    def _pick_group_var(self, df: pd.DataFrame) -> str | None:
+        """Find the 0/1 *group* column; ``did`` is the interaction, not the group."""
+        for col in self._GROUP_CANDIDATES:
+            if col in df.columns:
+                return col
+        return None
+
+    def step2b_gold_tables(self) -> Any:
+        """Run the gold-slot ladder so the package carries tables, not excuses."""
+        df = self.ctx.df
+        if df is None or df.empty:
+            _log.info("[Step 2b] 无面板，跳过黄金八格")
+            return None
+
+        group = self._pick_group_var(df)
+        if group is None or "post" not in df.columns:
+            _log.info("[Step 2b] 缺组别/时期列，跳过黄金八格（need group + post）")
+            return None
+
+        x_vars = [
+            c
+            for c in ("lev", "size", "tangibility", "mb", "cash_ratio")
+            if c in df.columns and c not in self.mechanism_vars
+        ]
+        try:
+            from scripts.research_framework.gold_tables import build_gold_tables
+
+            tables = build_gold_tables(
+                df,
+                y_var="roa",
+                treat_var=group,
+                time_var="post",
+                unit_col="ticker",
+                year_col="year",
+                x_vars=x_vars,
+                mechanism_vars=self.mechanism_vars,
+            )
+        except Exception as exc:
+            _log.warning("[Step 2b] 黄金八格失败: %s", exc)
+            self.ctx.step_results["step2b"] = {"status": "error", "error": str(exc)}
+            return None
+
+        self.ctx.gold_tables = tables
+        slots = tables.to_slots()
+        try:
+            md_path = self.output_dir / "GOLD_TABLES.md"
+            md_path.write_text(tables.to_markdown(), encoding="utf-8")
+            self.ctx.step_results["step2b"] = {
+                "status": "ok",
+                "slots": sorted(slots),
+                "markdown": str(md_path),
+            }
+            _log.info("[Step 2b] ✅ 黄金八格：%s → %s", sorted(slots), md_path)
+        except OSError as exc:
+            self.ctx.step_results["step2b"] = {"status": "ok", "slots": sorted(slots)}
+            _log.warning("[Step 2b] 表已算出但写盘失败: %s", exc)
+        return tables
 
     def _write_empirical_package(self) -> Path | None:
         """Emit an honest empirical_package.json after DID + robustness.
@@ -1350,6 +1419,14 @@ def _cli_main():
         default="",
         help="Path to local panel (csv/parquet/dta); checked before FINAI_EMPIRICAL_DATA_ROOT",
     )
+    parser.add_argument(
+        "--mechanism",
+        nargs="*",
+        default=[],
+        metavar="M",
+        help="Named mechanism channels (columns). Never auto-invented; "
+             "an M that is also a control is refused.",
+    )
     args = parser.parse_args()
 
     print(f"\n{'='*60}")
@@ -1375,6 +1452,7 @@ def _cli_main():
         explore=args.explore,
         allow_demo=args.allow_demo,
         panel_path=args.panel or None,
+        mechanism_vars=args.mechanism,
     )
 
     ctx = pipeline.run()

--- a/scripts/research_framework/gold_tables.py
+++ b/scripts/research_framework/gold_tables.py
@@ -1,0 +1,509 @@
+"""Gold-slot tables: run the ladder instead of only reporting it missing.
+
+The empirical package contract (``scripts/core/empirical_package.py``) asks for
+structure facts before the regression, a stepwise ladder, a tighter comparison,
+a sample flow with n at every step, and a treatment→mechanism table. Until now
+FinAI could only *report* those slots as missing.
+
+This module produces them from a panel, reusing ``pipeline.run_did`` so the
+estimates come from the same estimator the rest of the project uses.
+
+What it deliberately does **not** do:
+
+- Invent control ``job`` / ``basis`` text. Why a control is in the equation is
+  a thinking task; a generated sentence would be exactly the sticker the
+  contract rejects. Skeleton rows are emitted for a human to fill.
+- Invent mechanism channels. The caller must name M; the module then runs
+  treatment→M and refuses any M that is also in the control battery.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Sequence
+
+import pandas as pd
+
+__all__ = [
+    "LadderColumn",
+    "MechanismRow",
+    "GoldTableSet",
+    "build_gold_tables",
+    "figure_gate_from_event_study",
+]
+
+
+@dataclass
+class LadderColumn:
+    """One column of the stepwise / tighter-comparison table."""
+
+    label: str
+    coef: float
+    se: float
+    pval: float
+    n_obs: int
+    r_squared: float
+    controls: bool
+    unit_fe: bool
+    time_fe: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "label": self.label,
+            "coef": self.coef,
+            "se": self.se,
+            "pval": self.pval,
+            "n_obs": self.n_obs,
+            "r_squared": self.r_squared,
+            "controls": self.controls,
+            "unit_fe": self.unit_fe,
+            "time_fe": self.time_fe,
+        }
+
+
+@dataclass
+class MechanismRow:
+    """Treatment → M. Same estimator as the main column, M as the outcome."""
+
+    channel: str
+    coef: float
+    se: float
+    pval: float
+    n_obs: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "channel": self.channel,
+            "coef": self.coef,
+            "se": self.se,
+            "pval": self.pval,
+            "n_obs": self.n_obs,
+        }
+
+
+@dataclass
+class GoldTableSet:
+    y_var: str
+    treat_var: str
+    battery: list[str] = field(default_factory=list)
+    sample_flow: list[dict[str, Any]] = field(default_factory=list)
+    facts_before_reg: list[dict[str, Any]] = field(default_factory=list)
+    raw_did: float | None = None
+    desc: list[dict[str, Any]] = field(default_factory=list)
+    stepwise: list[LadderColumn] = field(default_factory=list)
+    tighter: LadderColumn | None = None
+    mechanism: list[MechanismRow] = field(default_factory=list)
+
+    @property
+    def main_column(self) -> LadderColumn | None:
+        return self.tighter or (self.stepwise[-1] if self.stepwise else None)
+
+    def to_slots(self) -> dict[str, str]:
+        """Slot ids for the empirical package. Only what actually ran."""
+        slots: dict[str, str] = {}
+        if self.desc:
+            slots["desc"] = f"T1 描述统计（{len(self.desc)} 个变量；定义列须人工补）"
+        if self.facts_before_reg:
+            slots["facts_before_reg"] = (
+                f"T2 回归前结构事实（{len(self.facts_before_reg)} 格组均值）"
+            )
+        if self.stepwise:
+            slots["baseline_stepwise"] = f"T3 逐步加信息（{len(self.stepwise)} 列）"
+        if self.tighter is not None:
+            slots["tighter_compare"] = f"T3 列（{self.tighter.label}）"
+        if self.sample_flow:
+            slots["sample_flow"] = f"A1 样本流（{len(self.sample_flow)} 步）"
+        if self.mechanism:
+            slots["mechanism"] = f"T4 处理→M（{len(self.mechanism)} 条渠道）"
+        return slots
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "y_var": self.y_var,
+            "treat_var": self.treat_var,
+            "battery": list(self.battery),
+            "sample_flow": self.sample_flow,
+            "facts_before_reg": self.facts_before_reg,
+            "raw_did": self.raw_did,
+            "desc": self.desc,
+            "stepwise": [c.to_dict() for c in self.stepwise],
+            "tighter": self.tighter.to_dict() if self.tighter else None,
+            "mechanism": [m.to_dict() for m in self.mechanism],
+        }
+
+    def to_markdown(self) -> str:
+        def stars(p: float) -> str:
+            return "***" if p < 0.01 else "**" if p < 0.05 else "*" if p < 0.10 else ""
+
+        out = [f"# 黄金八格实跑表 — {self.y_var}", ""]
+
+        if self.sample_flow:
+            out += ["## A1 样本流", "", "| 步骤 | 观测数 | 单位数 |", "|---|---|---|"]
+            out += [
+                f"| {r['step']} | {r['n_obs']} | {r.get('n_units', '')} |"
+                for r in self.sample_flow
+            ]
+            out.append("")
+
+        if self.facts_before_reg:
+            out += [
+                "## T2 回归前结构事实",
+                "",
+                "| 处理组 | 时期 | 观测数 | 均值 | 标准差 |",
+                "|---|---|---|---|---|",
+            ]
+            out += [
+                f"| {r['treat']} | {r['post']} | {r['n']} | {r['mean']:.4f} | {r['sd']:.4f} |"
+                for r in self.facts_before_reg
+            ]
+            if self.raw_did is not None:
+                out += ["", f"未调整 DiD（组均值之差的差）：{self.raw_did:.4f}"]
+            out.append("")
+
+        if self.stepwise:
+            cols = list(self.stepwise)
+            out += ["## T3 逐步加信息", ""]
+            out.append("| | " + " | ".join(f"({i + 1})" for i in range(len(cols))) + " |")
+            out.append("|---|" + "---|" * len(cols))
+            out.append(
+                f"| {self.treat_var} | "
+                + " | ".join(f"{c.coef:.4f}{stars(c.pval)}" for c in cols)
+                + " |"
+            )
+            out.append("| 标准误 | " + " | ".join(f"({c.se:.4f})" for c in cols) + " |")
+            out.append(
+                "| 控制变量 | " + " | ".join("是" if c.controls else "否" for c in cols) + " |"
+            )
+            out.append(
+                "| 单位固定效应 | "
+                + " | ".join("是" if c.unit_fe else "否" for c in cols)
+                + " |"
+            )
+            out.append(
+                "| 时间固定效应 | "
+                + " | ".join("是" if c.time_fe else "否" for c in cols)
+                + " |"
+            )
+            out.append("| 观测值 | " + " | ".join(str(c.n_obs) for c in cols) + " |")
+            out += ["", "注：*** p<0.01, ** p<0.05, * p<0.10。", ""]
+
+        if self.mechanism:
+            out += [
+                "## T4 处理→机制变量",
+                "",
+                "| 渠道 | 系数 | 标准误 | p 值 | 观测值 |",
+                "|---|---|---|---|---|",
+            ]
+            out += [
+                f"| {m.channel} | {m.coef:.4f}{stars(m.pval)} | ({m.se:.4f}) "
+                f"| {m.pval:.4f} | {m.n_obs} |"
+                for m in self.mechanism
+            ]
+            out += ["", "机制的理论链与假说同号，须人工写入 `mechanism_theory`。", ""]
+
+        out += [
+            "## 仍须人工补",
+            "",
+            "- 每件控制的 `job`（接到本题 Y 或名单选择）与 `basis`（打开过的定义 + 本题路径）。",
+            "- 变量定义列（T1 只有描述统计）。",
+            "- 事件图 0 点职务句（名单公布年还是落地年）。",
+        ]
+        return "\n".join(out)
+
+
+def _units(df: pd.DataFrame, unit_col: str) -> int | str:
+    return int(df[unit_col].nunique()) if unit_col in df.columns else ""
+
+
+def _absorb(frame: pd.DataFrame, cols: list[str], group: pd.Series) -> pd.DataFrame:
+    """Within-transform every regressor *and* the outcome by one FE dimension.
+
+    ``pipeline.run_did`` deliberately leaves the interaction on its original
+    scale, which breaks Frisch-Waugh and attenuates the coefficient. The whole
+    design matrix has to be residualised on the same fixed effects.
+    """
+    out = frame.copy()
+    means = out.groupby(group, observed=True)[cols].transform("mean")
+    for col in cols:
+        out[col] = out[col] - means[col]
+    return out
+
+
+def _column(
+    df: pd.DataFrame,
+    *,
+    label: str,
+    y_var: str,
+    treat_var: str,
+    time_var: str,
+    x_vars: Sequence[str],
+    unit_col: str,
+    year_col: str,
+    unit_fe: bool,
+    time_fe: bool,
+) -> LadderColumn:
+    import statsmodels.api as sm
+
+    did_name = "_did_term"
+    frame = pd.DataFrame(index=df.index)
+    frame[y_var] = pd.to_numeric(df[y_var], errors="coerce")
+    treat = pd.to_numeric(df[treat_var], errors="coerce")
+    post = pd.to_numeric(df[time_var], errors="coerce")
+    frame[did_name] = treat * post
+    # Group indicator is collinear with unit FE; post with time FE.
+    regressors = [did_name]
+    if not unit_fe:
+        frame[treat_var] = treat
+        regressors.append(treat_var)
+    if not time_fe:
+        frame[time_var] = post
+        regressors.append(time_var)
+    for xv in x_vars:
+        frame[xv] = pd.to_numeric(df[xv], errors="coerce")
+        regressors.append(xv)
+
+    frame = frame.dropna()
+    if frame.empty:
+        raise ValueError(f"{label}: 去缺失后无观测")
+
+    cols = [y_var, *regressors]
+    if unit_fe:
+        frame = _absorb(frame, cols, df.loc[frame.index, unit_col])
+    if time_fe:
+        frame = _absorb(frame, cols, df.loc[frame.index, year_col])
+
+    X = sm.add_constant(frame[regressors].astype(float), has_constant="add")
+    model = sm.OLS(frame[y_var].astype(float), X).fit(cov_type="HC1")
+    return LadderColumn(
+        label=label,
+        coef=float(model.params[did_name]),
+        se=float(model.bse[did_name]),
+        pval=float(model.pvalues[did_name]),
+        n_obs=int(model.nobs),
+        r_squared=float(model.rsquared),
+        controls=bool(x_vars),
+        unit_fe=unit_fe,
+        time_fe=time_fe,
+    )
+
+
+def build_gold_tables(
+    df: pd.DataFrame,
+    *,
+    y_var: str,
+    treat_var: str,
+    time_var: str,
+    unit_col: str = "ticker",
+    year_col: str = "year",
+    x_vars: Sequence[str] = (),
+    mechanism_vars: Sequence[str] = (),
+) -> GoldTableSet:
+    """Run the seed-paper ladder + JDE sample flow on a real panel.
+
+    ``treat_var`` is the group indicator and ``time_var`` the post indicator;
+    the interaction is built by ``run_did``.
+
+    Raises
+    ------
+    ValueError
+        If a mechanism variable is also a control. Same construct cannot be
+        both battery and channel — the contract rejects it downstream anyway,
+        so fail here rather than emit a table that can never pass the gate.
+    """
+    for col in (y_var, treat_var, time_var):
+        if col not in df.columns:
+            raise ValueError(f"面板缺少必需列 {col!r}")
+
+    battery = [c for c in x_vars if c in df.columns]
+    overlap = sorted(set(battery) & set(mechanism_vars))
+    if overlap:
+        raise ValueError(
+            f"机制渠道与控制电池同构念：{overlap}；同一变量不能既当控制又当 M"
+        )
+
+    tables = GoldTableSet(y_var=y_var, treat_var=treat_var, battery=battery)
+
+    # ── A1 sample flow ──────────────────────────────────────────────────
+    tables.sample_flow.append(
+        {"step": "原始面板", "n_obs": len(df), "n_units": _units(df, unit_col)}
+    )
+    core = df.dropna(subset=[y_var, treat_var, time_var])
+    tables.sample_flow.append(
+        {
+            "step": f"去缺失（{y_var} / {treat_var} / {time_var}）",
+            "n_obs": len(core),
+            "n_units": _units(core, unit_col),
+        }
+    )
+    est = core.dropna(subset=battery) if battery else core
+    if battery:
+        tables.sample_flow.append(
+            {
+                "step": f"去缺失（{len(battery)} 件控制）",
+                "n_obs": len(est),
+                "n_units": _units(est, unit_col),
+            }
+        )
+    tables.sample_flow.append(
+        {"step": "估计样本", "n_obs": len(est), "n_units": _units(est, unit_col)}
+    )
+
+    if est.empty:
+        return tables
+
+    # ── T2 structure facts before the regression ────────────────────────
+    cells: dict[tuple[int, int], dict[str, Any]] = {}
+    for (g, t), grp in est.groupby(
+        [est[treat_var].astype(int), est[time_var].astype(int)]
+    ):
+        cell = {
+            "treat": int(g),
+            "post": int(t),
+            "n": int(len(grp)),
+            "mean": float(grp[y_var].mean()),
+            "sd": float(grp[y_var].std(ddof=1)) if len(grp) > 1 else 0.0,
+        }
+        cells[(int(g), int(t))] = cell
+        tables.facts_before_reg.append(cell)
+    tables.facts_before_reg.sort(key=lambda r: (r["treat"], r["post"]))
+    if len(cells) == 4:
+        tables.raw_did = (
+            cells[(1, 1)]["mean"] - cells[(1, 0)]["mean"]
+        ) - (cells[(0, 1)]["mean"] - cells[(0, 0)]["mean"])
+
+    # ── T1 descriptive stats (definitions stay a human column) ──────────
+    for col in [y_var, treat_var, time_var, *battery]:
+        series = pd.to_numeric(est[col], errors="coerce").dropna()
+        if series.empty:
+            continue
+        tables.desc.append(
+            {
+                "variable": col,
+                "n": int(series.size),
+                "mean": float(series.mean()),
+                "sd": float(series.std(ddof=1)) if series.size > 1 else 0.0,
+                "min": float(series.min()),
+                "max": float(series.max()),
+            }
+        )
+
+    # ── T3 stepwise ladder, then the tighter comparison ─────────────────
+    ladder: list[tuple[str, Sequence[str], bool, bool]] = [
+        ("裸估计", (), False, False),
+        ("+ 时间固定效应", (), False, True),
+    ]
+    if battery:
+        ladder.append(("+ 控制变量", battery, False, True))
+    steps = ladder
+    for label, controls, unit_fe, time_fe in steps:
+        try:
+            tables.stepwise.append(
+                _column(
+                    est,
+                    label=label,
+                    y_var=y_var,
+                    treat_var=treat_var,
+                    time_var=time_var,
+                    x_vars=controls,
+                    unit_col=unit_col,
+                    year_col=year_col,
+                    unit_fe=unit_fe,
+                    time_fe=time_fe,
+                )
+            )
+        except Exception:  # one column failing must not kill the table
+            continue
+
+    try:
+        tables.tighter = _column(
+            est,
+            label="+ 单位×时间固定效应",
+            y_var=y_var,
+            treat_var=treat_var,
+            time_var=time_var,
+            x_vars=battery,
+            unit_col=unit_col,
+            year_col=year_col,
+            unit_fe=True,
+            time_fe=True,
+        )
+        tables.stepwise.append(tables.tighter)
+    except Exception:
+        tables.tighter = None
+
+    # ── T4 treatment → mechanism ────────────────────────────────────────
+    for m in mechanism_vars:
+        if m not in est.columns:
+            continue
+        sub = est.dropna(subset=[m])
+        if sub.empty:
+            continue
+        try:
+            col = _column(
+                sub,
+                label=m,
+                y_var=m,
+                treat_var=treat_var,
+                time_var=time_var,
+                x_vars=battery,
+                unit_col=unit_col,
+                year_col=year_col,
+                unit_fe=True,
+                time_fe=True,
+            )
+        except Exception:
+            continue
+        tables.mechanism.append(
+            MechanismRow(
+                channel=m,
+                coef=col.coef,
+                se=col.se,
+                pval=col.pval,
+                n_obs=col.n_obs,
+            )
+        )
+
+    return tables
+
+
+def figure_gate_from_event_study(
+    event_rows: Iterable[Any],
+    *,
+    placebo_tail_p: float | None = None,
+) -> dict[str, Any]:
+    """Count post-period CIs that cross zero — the figure door, measured.
+
+    ``event_rows`` is what ``ModernDiDEngine.event_study_data`` produces
+    (records with horizon / ci_lower / ci_upper).
+    """
+    post_n = 0
+    cross0 = 0
+    pre_pvals: list[float] = []
+    for row in event_rows or []:
+        if not isinstance(row, dict):
+            continue
+        try:
+            horizon = float(row.get("horizon"))
+            lo = float(row.get("ci_lower"))
+            hi = float(row.get("ci_upper"))
+        except (TypeError, ValueError):
+            continue
+        if horizon > 0:
+            post_n += 1
+            if lo <= 0.0 <= hi:
+                cross0 += 1
+        elif horizon < 0:
+            try:
+                pre_pvals.append(float(row.get("pval")))
+            except (TypeError, ValueError):
+                pass
+
+    gate: dict[str, Any] = {
+        "event_post_n": post_n,
+        "event_post_cross0_n": cross0,
+    }
+    if pre_pvals:
+        gate["event_pre_min_p"] = min(pre_pvals)
+    if placebo_tail_p is not None:
+        gate["placebo_tail_p"] = float(placebo_tail_p)
+        gate["placebo_true_outside_mass"] = float(placebo_tail_p) <= 0.05
+    return gate

--- a/tests/test_empirical_package.py
+++ b/tests/test_empirical_package.py
@@ -187,9 +187,15 @@ def test_empty_scaffold_cli_shape():
     assert "placebo" not in pkg["slots"]
 
 
-def test_writing_pre_gate_does_not_search_shared_output_by_default():
-    """Default writing track must not pick up a leftover output/*.json."""
+def test_writing_pre_gate_searches_where_empirics_writes_the_package(tmp_path: Path):
+    """Stage 6 → Stage 7 contract: the gate must look where empirics drops it."""
     from scripts.core.empirical_package import EmpiricalPackageReport
+    from scripts.research_framework.enhanced_pipeline import EnhancedPipeline
+
+    written = EnhancedPipeline(
+        topic="ESG", output_dir=tmp_path / "run", enable_hitl=False
+    )._write_empirical_package()
+    assert written is not None, "empirics must emit a package after DID + robustness"
 
     cfg = AgentPipelineConfig(topic="t")
     pipeline = AgentPipeline(cfg)
@@ -198,9 +204,7 @@ def test_writing_pre_gate_does_not_search_shared_output_by_default():
 
     def _check(**kwargs):
         seen["dirs"] = [Path(p) for p in (kwargs.get("search_dirs") or [])]
-        return EmpiricalPackageReport(
-            passed=True, skipped=True, summary_message="skip"
-        )
+        return EmpiricalPackageReport(passed=True, skipped=True, summary_message="skip")
 
     with patch(
         "scripts.core.empirical_package.check_empirical_package",
@@ -217,8 +221,16 @@ def test_writing_pre_gate_does_not_search_shared_output_by_default():
     ):
         pipeline._run_writing_pre_gate(result, "理论综述，无回归结果。")
 
-    assert Path("output") not in seen.get("dirs", [])
-    assert Path("output/fin-refinement") in seen.get("dirs", [])
+    # enhanced_pipeline defaults to output/; the default gate must cover that dir.
+    import inspect
+
+    default_out = Path(
+        str(inspect.signature(EnhancedPipeline.__init__).parameters["output_dir"].default)
+    )
+    assert written.name == "empirical_package.json"
+    assert (default_out / written.name) in {
+        d / written.name for d in seen.get("dirs", [])
+    }
     assert result.quality_reports["writing_pre_gate"]["passed"] is True
 
 

--- a/tests/test_gold_tables.py
+++ b/tests/test_gold_tables.py
@@ -1,0 +1,134 @@
+"""Gold-slot tables must actually run, and refuse contract-violating input."""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from scripts.research_framework.gold_tables import (
+    build_gold_tables,
+    figure_gate_from_event_study,
+)
+
+
+def _panel(n_firms: int = 40, effect: float = 0.05) -> pd.DataFrame:
+    rng = np.random.default_rng(7)
+    rows = []
+    for i in range(n_firms):
+        treat = int(i % 2 == 0)
+        for year in range(2016, 2022):
+            post = int(year >= 2019)
+            rows.append(
+                {
+                    "ticker": f"F{i:03d}",
+                    "year": year,
+                    "esg_high": treat,
+                    "post": post,
+                    "roa": 0.03 + effect * treat * post + rng.normal(0, 0.01),
+                    "lev": rng.normal(0.35, 0.1),
+                    "size": rng.normal(21.0, 1.0),
+                    "cash_ratio": 0.1 + 0.04 * treat * post + rng.normal(0, 0.01),
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def _build(**kw):
+    return build_gold_tables(
+        _panel(),
+        y_var="roa",
+        treat_var="esg_high",
+        time_var="post",
+        unit_col="ticker",
+        year_col="year",
+        **kw,
+    )
+
+
+def test_sample_flow_records_n_at_every_step():
+    t = _build(x_vars=["lev", "size"])
+    steps = [r["step"] for r in t.sample_flow]
+    assert steps[0] == "原始面板"
+    assert steps[-1] == "估计样本"
+    assert all(r["n_obs"] > 0 for r in t.sample_flow)
+    assert t.sample_flow[0]["n_units"] == 40
+
+
+def test_structure_facts_are_a_2x2_with_raw_did():
+    t = _build(x_vars=["lev"])
+    assert len(t.facts_before_reg) == 4
+    assert {(r["treat"], r["post"]) for r in t.facts_before_reg} == {
+        (0, 0), (0, 1), (1, 0), (1, 1)
+    }
+    # Planted effect is +0.05; the unadjusted 2x2 difference must recover it.
+    assert t.raw_did == pytest.approx(0.05, abs=0.01)
+
+
+def test_stepwise_ladder_adds_information_column_by_column():
+    t = _build(x_vars=["lev", "size"])
+    labels = [c.label for c in t.stepwise]
+    assert labels[0] == "裸估计"
+    assert "+ 控制变量" in labels
+    assert t.tighter is not None
+    assert t.tighter.unit_fe and t.tighter.time_fe
+    assert t.tighter.controls
+    # The tighter column is the last one, i.e. the main column.
+    assert t.main_column is t.tighter
+    assert t.main_column.coef == pytest.approx(0.05, abs=0.02)
+    assert t.main_column.pval < 0.05
+
+
+def test_slots_only_claim_what_ran():
+    t = _build(x_vars=["lev"])
+    slots = t.to_slots()
+    for name in ("desc", "facts_before_reg", "baseline_stepwise", "tighter_compare", "sample_flow"):
+        assert name in slots
+    assert "mechanism" not in slots, "no named M means no mechanism slot"
+
+
+def test_named_mechanism_produces_a_t_to_m_table():
+    t = _build(x_vars=["lev", "size"], mechanism_vars=["cash_ratio"])
+    assert [m.channel for m in t.mechanism] == ["cash_ratio"]
+    assert t.mechanism[0].coef == pytest.approx(0.04, abs=0.02)
+    assert "mechanism" in t.to_slots()
+
+
+def test_mechanism_cannot_double_as_a_control():
+    with pytest.raises(ValueError, match="同构念"):
+        _build(x_vars=["lev", "cash_ratio"], mechanism_vars=["cash_ratio"])
+
+
+def test_missing_required_column_is_refused():
+    with pytest.raises(ValueError, match="缺少必需列"):
+        build_gold_tables(
+            _panel().drop(columns=["post"]),
+            y_var="roa",
+            treat_var="esg_high",
+            time_var="post",
+        )
+
+
+def test_markdown_prints_tables_and_the_human_todo():
+    md = _build(x_vars=["lev"], mechanism_vars=["cash_ratio"]).to_markdown()
+    assert "## A1 样本流" in md
+    assert "## T3 逐步加信息" in md
+    assert "## T4 处理→机制变量" in md
+    assert "仍须人工补" in md
+
+
+def test_figure_gate_counts_post_period_ci_crossings():
+    rows = [
+        {"horizon": -2, "ci_lower": -0.01, "ci_upper": 0.01, "pval": 0.8},
+        {"horizon": 1, "ci_lower": 0.01, "ci_upper": 0.05, "pval": 0.01},
+        {"horizon": 2, "ci_lower": -0.01, "ci_upper": 0.06, "pval": 0.20},
+    ]
+    gate = figure_gate_from_event_study(rows, placebo_tail_p=0.02)
+    assert gate["event_post_n"] == 2
+    assert gate["event_post_cross0_n"] == 1
+    assert gate["placebo_true_outside_mass"] is True
+    assert gate["event_pre_min_p"] == pytest.approx(0.8)
+
+
+def test_figure_gate_tolerates_garbage_rows():
+    gate = figure_gate_from_event_study([{"horizon": "x"}, "junk", {}])
+    assert gate == {"event_post_n": 0, "event_post_cross0_n": 0}


### PR DESCRIPTION
## Summary

Follow-up to #204, which shipped the write-gate contract but left it unable to protect anything in the default configuration.

- **Repair the hand-off.** `enhanced_pipeline` writes `output/empirical_package.json`, but the writing pre-gate no longer searched `output/` — a CI workaround from #204 had leaked into production behaviour, so Stage 6 → Stage 7 silently skipped W5. Restored, plus a contract test pinning the gate's search path to where the empirics track actually writes.
- **Run the gold slots instead of only reporting them missing.** New `scripts/research_framework/gold_tables.py`, wired as `step2b`: sample flow with n at every step, 2×2 structure facts before the regression, the stepwise ladder, the tighter (unit×time FE) comparison, and treatment→M for every channel named via `--mechanism`. Emits `GOLD_TABLES.md`. A demo run now fills 10 package slots automatically; only `exclusive` / `hetero` stay dropped.
- **The ladder needed its own estimator.** `pipeline.run_did` demeans the outcome and controls but leaves the DID interaction on its original scale, which breaks Frisch-Waugh: on a panel with a planted 0.05 effect it returns 0.013. `gold_tables` absorbs the whole design matrix and recovers the planted effect. `run_did` itself is left untouched (demo track; separate blast radius) — flagged for a follow-up decision.
- **Fix a silent pre-existing failure.** `ProvenanceTracker(output_dir=...)` takes no such argument, so LaTeX generation in the empirics track died inside a bare `except` on every run.
- **Audit check 26** guards all four links (emit / search path / call site / gold tables). Each link was individually broken and confirmed to fail the check — the first two drafts of it were tautological and passed against a broken tree.

Mechanism channels are never invented: the caller names M, and an M that is also in the control battery is refused at build time. Control `job` / `basis` and `mechanism_theory` stay empty by design — generated text there is exactly the sticker the contract rejects, so the gate keeps asking the human.

## Test plan

- [x] `pytest tests/` — 13035 passed, 147 skipped, 0 failed (11m34s)
- [x] `python scripts/audit_guard.py` — 26/26
- [x] Negative-tested check 26 by breaking each of the four links in turn
- [x] `ruff check` on all changed files
- [x] End-to-end: empirics run → `GOLD_TABLES.md` + package → gate blocks on the human-judgment items only
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)