### PR TITLE
feat: port story-page and method-family contracts into the write-gate

### DIFF
--- a/.agents/skills/fin-experiment-design/SKILL.md
+++ b/.agents/skills/fin-experiment-design/SKILL.md
@@ -39,7 +39,7 @@ python -m scripts.core.empirical_package audit output/fin-refinement/empirical_p
 python -m scripts.research_framework.enhanced_pipeline --topic "..." --mechanism 渠道列名
 ```
 
-`empirical_package.json` 最低要求：`y_construct` / `x_construct`、每件控制的 `variable_jobs`（中文 `table_row` + 接到本题 Y 的 `job` + 非贴纸 `basis`）、黄金八格（缺格写 `dropped` 理由）、政策 DID 还要独立于电池的 `mechanism_channels` 与 `figure_gate`。政策 DID 不得 `dropped: mechanism`。交稿是合取：主栏显著 ∧ 控制有职务 ∧ 活机制表 ∧ 图干净。
+`empirical_package.json` 最低要求：`y_construct` / `x_construct`、每件控制的 `variable_jobs`（中文 `table_row` + 接到本题 Y 的 `job` + 非贴纸 `basis`）、黄金八格（缺格写 `dropped` 理由）、政策 DID 还要独立于电池的 `mechanism_channels`（≥2 条且不是本题 Y）与 `figure_gate`。`mechanism_methods` 按推断家族计数（sobel+bootstrap 只算一种）。政策 DID 不得 `dropped: mechanism`。交稿是合取：主栏显著 ∧ 控制有职务 ∧ 活机制表 ∧ 图干净 ∧ 能复述的 `story` 页。H1 必须是主发现，禁止写「H1 被拒绝」。
 
 ## 前置条件
 

--- a/.cursor/skills/fin-experiment-design/SKILL.md
+++ b/.cursor/skills/fin-experiment-design/SKILL.md
@@ -39,7 +39,7 @@ python -m scripts.core.empirical_package audit output/fin-refinement/empirical_p
 python -m scripts.research_framework.enhanced_pipeline --topic "..." --mechanism 渠道列名
 ```
 
-`empirical_package.json` 最低要求：`y_construct` / `x_construct`、每件控制的 `variable_jobs`（中文 `table_row` + 接到本题 Y 的 `job` + 非贴纸 `basis`）、黄金八格（缺格写 `dropped` 理由）、政策 DID 还要独立于电池的 `mechanism_channels` 与 `figure_gate`。政策 DID 不得 `dropped: mechanism`。交稿是合取：主栏显著 ∧ 控制有职务 ∧ 活机制表 ∧ 图干净。
+`empirical_package.json` 最低要求：`y_construct` / `x_construct`、每件控制的 `variable_jobs`（中文 `table_row` + 接到本题 Y 的 `job` + 非贴纸 `basis`）、黄金八格（缺格写 `dropped` 理由）、政策 DID 还要独立于电池的 `mechanism_channels`（≥2 条且不是本题 Y）与 `figure_gate`。`mechanism_methods` 按推断家族计数（sobel+bootstrap 只算一种）。政策 DID 不得 `dropped: mechanism`。交稿是合取：主栏显著 ∧ 控制有职务 ∧ 活机制表 ∧ 图干净 ∧ 能复述的 `story` 页。H1 必须是主发现，禁止写「H1 被拒绝」。
 
 ## 前置条件
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,7 +141,7 @@ HITL protocol (`AgentOrchestrator` / `AgentPipeline`):
 4. **Journals** — 30 templates available. Default venue: 经济研究 (Chinese) / JF (English). User can override via `--venue`.
 5. **HITL** — pause at every stage transition. Never auto-skip a confirmation gate.
 6. **No silent fallback to mock data** — fetch() raises if all layers fail unless user opts in.
-7. **Empirical package before causal claims** — a policy DID is gold slots + live T→M table, not one TWFE coefficient. Controls need jobs attached to *this* Y. Do not drop mechanism on core mode. Do not write 「研究发现」 when `main_p>0.10` or the event-study figure is dirty.
+7. **Empirical package before causal claims** — a policy DID is gold slots + live T→M table + a retellable story page, not one TWFE coefficient. Controls need jobs attached to *this* Y. Core needs ≥2 named channels from constructs other than Y, and two mechanism methods from *different inference families*. Do not drop mechanism on core mode. Do not write 「研究发现」 when `main_p>0.10` or the event-study figure is dirty. Do not write 「H1 被拒绝」— rewrite the question. Claim ≤ tables; do not ship a whole output folder as the submission.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,7 +236,7 @@ output/                           # 输出目录
 | `scripts/research_framework/pipeline.py` | 实证 demo TWFE + design scaffold（非写作轨）|
 | `scripts/research_framework/enhanced_pipeline.py` | 实证生产入口（现代 DID；`--mechanism` 指定渠道；写出 `GOLD_TABLES.md` + `empirical_package.json`）|
 | `scripts/research_framework/gold_tables.py` | 黄金八格实跑表（结构事实 / 逐步 / 更紧 / 样本流 / 处理→M）|
-| `scripts/core/empirical_package.py` | 实证包写稿门（黄金八格 / 控制职务 / 机制分列 / 图门）|
+| `scripts/core/empirical_package.py` | 实证包写稿门（黄金八格 / 控制职务 / 机制分族 / 故事页 / 图门）|
 | `scripts/research_framework/modern_did.py` | 现代 DID 库（import，无独立 CLI）|
 | `scripts/research_framework/fin_charts.py` | 专业金融图表 |
 | `scripts/research_framework/report_generator.py` | LaTeX 论文生成 |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -27,8 +27,10 @@ comparison, sample flow, and treatment→M for every channel named via
 figure gate; whatever it did not run stays `dropped`). The writing pre-gate reads
 it (`scripts/core/empirical_package.py`) and blocks the draft unless the main
 column is significant, controls carry jobs tied to *this* Y, a live mechanism
-table exists, and the genre's fourth piece holds. No package → writing-only
-track, gate soft-skips.
+table exists, the genre's fourth piece holds, and a core package has a
+retellable `story` page (question / tension / number-free answer / pitch).
+Mechanism methods count by inference family; M is not Y. No package →
+writing-only track, gate soft-skips.
 
 > **CLI 入口 (写作轨)**
 >

--- a/scripts/audit_guard.py
+++ b/scripts/audit_guard.py
@@ -1696,11 +1696,20 @@ def _check_empirical_package_wiring() -> CheckResult:
     if has_gold:
         evidence.append("gold-slot tables run in step2b")
 
-    ok = emits and searches_default and called and has_gold
+    gate_src = gate.read_text(encoding="utf-8")
+    has_story_contract = (
+        "MECHANISM_METHOD_FAMILIES" in gate_src
+        and "def _validate_core_story_and_type" in gate_src
+        and "mechanism_is_y" in gate_src
+    )
+    if has_story_contract:
+        evidence.append("write-gate has story + method-family + M≠Y contract")
+
+    ok = emits and searches_default and called and has_gold and has_story_contract
     return CheckResult(
         passed=ok,
-        expected="emit + search-path + call-site + gold tables all wired",
-        actual=f"{len(evidence)}/4 links present",
+        expected="emit + search-path + call-site + gold tables + story contract all wired",
+        actual=f"{len(evidence)}/5 links present",
         evidence=evidence,
     )
 

--- a/scripts/core/empirical_package.py
+++ b/scripts/core/empirical_package.py
@@ -13,7 +13,9 @@ It encodes only reusable contracts:
 3. Mechanism channels must be disjoint from the control battery.
 4. Write-gate conjunction: significant main column ∧ jobs ∧ live mechanism
    ∧ genre-appropriate fourth piece (clean event/placebo figures for policy
-   DID; tighter compare for cross-section).
+   DID; tighter compare for cross-section) ∧ retellable story page (core).
+5. Mechanism methods count by *inference family*, not token count. M is not Y.
+   Core needs ≥2 named channels. H1 is the finding — "H1 被拒绝" fails.
 
 Writing-only tracks without a package file soft-skip. A present package that
 fails the conjunction blocks the writing pre-gate.
@@ -31,6 +33,8 @@ __all__ = [
     "GOLD_SLOTS",
     "CORE_OVERLAY_SLOTS",
     "THINKING_QUESTIONS",
+    "MECHANISM_METHOD_FAMILIES",
+    "method_families",
     "PackageFinding",
     "EmpiricalPackageReport",
     "empty_package",
@@ -78,6 +82,36 @@ THINKING_QUESTIONS: tuple[str, ...] = (
     "机制渠道与控制电池是否同构念？同一活动换分母不能既控制又机制。",
     "机制是处理→点名 M 的表，还是道歉段 / 节标题 / 把主 Y 切片？政策 DID 不得 dropped 机制。",
     "第四件随体裁：政策 DID 要事件图处理后 CI 不跨 0；截面要更紧比较站住。过一扇门不能交。",
+    "故事页先于表：一句问题、一句张力、一句无数字答案、能复述的讲稿；搜完只改答案不改问题。",
+    "H1 必须是主发现。符号/显著性对不上就重定问题或停线，禁止写「H1 被拒绝」。",
+    "机制渠道不得是本题 Y；两条渠道须是可区分路径，不是同一构念换名。",
+    "两种机制测法必须来自不同推断家族（两步法 / 中介区间 / 调节 / 时序），同族两个词只算一种。",
+)
+
+# Token → inference family. Two tokens in one family count as one method.
+MECHANISM_METHOD_FAMILIES: dict[str, frozenset[str]] = {
+    "twostep": frozenset({"jiangting", "two_step", "twostep", "did_on_m", "t_to_m"}),
+    "stepwise_indirect": frozenset(
+        {"sobel", "bootstrap", "m_in_y", "stepwise", "four_step"}
+    ),
+    "moderation": frozenset(
+        {"did_x_base_m", "did_x_baseline", "treat_x_baseline", "moderation"}
+    ),
+    "system": frozenset({"sur", "sem"}),
+    "causal_med": frozenset({"causal_mediation", "imai"}),
+    "timing": frozenset({"timing", "m_event_study"}),
+    "micro": frozenset({"micro", "household"}),
+    "exclusion": frozenset({"exclusion", "blocked_channel"}),
+}
+
+_POLICY_TYPES = frozenset({"project_system", "advocacy", "mixed", "not_policy"})
+_NUM_IN_PROSE = re.compile(r"\d+\.\d+|%")
+_H1_REJECTED = re.compile(r"假说\s*H\s*1.{0,8}(被拒绝|未得到验证)|H\s*1.{0,6}被拒绝")
+_WORK_LANGUAGE = (
+    "前站",
+    "吸收层",
+    "名单效应",
+    "框架的推论",
 )
 
 _STICKER_EXACT = re.compile(
@@ -135,6 +169,25 @@ def thinking_questions() -> tuple[str, ...]:
     return THINKING_QUESTIONS
 
 
+def method_families(methods: Iterable[str]) -> list[str]:
+    """Map method tokens to inference families; unknowns stay distinct."""
+    out: list[str] = []
+    seen: set[str] = set()
+    for raw in methods:
+        token = _norm(str(raw))
+        if not token:
+            continue
+        family = f"other:{token}"
+        for name, aliases in MECHANISM_METHOD_FAMILIES.items():
+            if token in aliases or token == _norm(name):
+                family = name
+                break
+        if family not in seen:
+            seen.add(family)
+            out.append(family)
+    return out
+
+
 def empty_package(*, mode: str = "gold", unit: str = "firm") -> dict[str, Any]:
     """Scaffold a package. Questions first; do not copy example channel names."""
     if mode not in MODES:
@@ -162,11 +215,26 @@ def empty_package(*, mode: str = "gold", unit: str = "firm") -> dict[str, Any]:
         "mechanism_theory": "",
         "figure_gate": {},
         "null_effect": False,
+        "framework": "",
+        "policy_type": "",
+        "policy_type_basis": "",
+        "story": {},
     }
 
 
 def _norm(text: str) -> str:
     return re.sub(r"[\s_\-]+", "", (text or "").lower())
+
+
+def _same_construct(a: str, b: str) -> bool:
+    na, nb = _norm(a), _norm(b)
+    if not na or not nb:
+        return False
+    if na == nb:
+        return True
+    strip = r"(对数|率|比重|存量|规模|余额|深度)$"
+    sa, sb = re.sub(strip, "", na), re.sub(strip, "", nb)
+    return bool(sa and sb and len(sa) >= 4 and sa == sb)
 
 
 def _dropped_slots(pkg: Mapping[str, Any]) -> dict[str, str]:
@@ -315,9 +383,21 @@ def validate_package(pkg: Mapping[str, Any]) -> list[PackageFinding]:
                 f"机制渠道与控制/lock 同构念：{overlap}。同一构念不能既进电池又进 M",
             )
         )
-    if mode == "core" and not channels:
+    if mode == "core" and y_construct and any(_same_construct(c, y_construct) for c in channels):
         findings.append(
-            PackageFinding("error", "mechanism_channels", "政策 DID 须点名至少一条独立 M")
+            PackageFinding(
+                "error",
+                "mechanism_is_y",
+                "机制渠道不得是本题 Y（贷款题禁再印贷款对数/存量/深度）",
+            )
+        )
+    if mode == "core" and len(channels) < 2:
+        findings.append(
+            PackageFinding(
+                "error",
+                "mechanism_channels",
+                "政策 DID 须点名至少两条可区分路径的独立 M，不是一条渠道换名",
+            )
         )
     theory = str(pkg.get("mechanism_theory") or "").strip()
     if mode == "core" and (not theory or "借鉴" in theory and "→" not in theory):
@@ -329,14 +409,19 @@ def validate_package(pkg: Mapping[str, Any]) -> list[PackageFinding]:
             )
         )
     methods = [str(m).strip() for m in (pkg.get("mechanism_methods") or []) if str(m).strip()]
-    if mode == "core" and channels and len(methods) < 2:
+    families = method_families(methods)
+    if mode == "core" and channels and len(families) < 2:
         findings.append(
             PackageFinding(
                 "error",
                 "mechanism_methods",
-                "活渠道须两种测法（如 jiangting / sobel / did_x_m）并印在机制表上",
+                "活渠道须两种不同推断家族的测法（两步法 / 中介区间 / 调节 / 时序），"
+                "sobel+bootstrap 只算一种",
             )
         )
+
+    if mode == "core":
+        findings.extend(_validate_core_story_and_type(pkg))
 
     if not str(pkg.get("main_col") or "").strip():
         findings.append(PackageFinding("error", "main_col", "必须点名主栏（哪一列是交卷列）"))
@@ -344,8 +429,90 @@ def validate_package(pkg: Mapping[str, Any]) -> list[PackageFinding]:
     return findings
 
 
+def _answer_covered(answer: str, body: str) -> bool:
+    a = re.sub(r"\s+", "", answer or "")
+    b = re.sub(r"\s+", "", body or "")
+    if len(a) < 8:
+        return bool(a) and a in b
+    chunks = [a[i : i + 6] for i in range(0, len(a) - 5)]
+    hits = sum(1 for c in chunks if c in b)
+    return hits >= max(1, len(chunks) // 2)
+
+
+def _validate_core_story_and_type(pkg: Mapping[str, Any]) -> list[PackageFinding]:
+    findings: list[PackageFinding] = []
+    policy = str(pkg.get("policy_type") or "").strip()
+    if policy not in _POLICY_TYPES:
+        findings.append(
+            PackageFinding(
+                "error",
+                "policy_type",
+                "政策 DID 须定型 policy_type：project_system / advocacy / mixed / not_policy",
+            )
+        )
+    elif policy != "not_policy" and len(str(pkg.get("policy_type_basis") or "").strip()) < 8:
+        findings.append(
+            PackageFinding(
+                "error",
+                "policy_type_basis",
+                "须写哪个部门/有无专项资金，用来决定 M 家族，不能只填类型名",
+            )
+        )
+    framework = str(pkg.get("framework") or "").strip()
+    if len(framework) < 12:
+        findings.append(
+            PackageFinding(
+                "error",
+                "framework",
+                "须一句总框架（基于……理论 / 在……框架下），机制与异质都答这句派生的问题",
+            )
+        )
+
+    story = pkg.get("story") if isinstance(pkg.get("story"), Mapping) else {}
+    if not story:
+        findings.append(
+            PackageFinding(
+                "error",
+                "story",
+                "政策 DID 须有 story 块（问题 / 张力 / 无数字答案 / 讲稿 / ≥4 拍），故事页先于表",
+            )
+        )
+        return findings
+    question = str(story.get("question") or "").strip()
+    if len(question) < 10 or not re.search(r"[？?]|能否|是否|如何", question):
+        findings.append(
+            PackageFinding("error", "story_question", "story.question 须是一句带问号或能否/是否/如何的问题")
+        )
+    tension = str(story.get("tension") or "").strip()
+    if len(tension) < 16:
+        findings.append(PackageFinding("error", "story_tension", "story.tension 须写清答案为什么不显然"))
+    answer = str(story.get("answer") or "").strip()
+    if len(answer) < 16:
+        findings.append(PackageFinding("error", "story_answer", "story.answer 须一句无数字答案"))
+    elif _NUM_IN_PROSE.search(answer):
+        findings.append(PackageFinding("error", "story_answer", "story.answer 不许带小数或百分号"))
+    pitch = str(story.get("pitch") or "").strip()
+    if not (150 <= len(pitch) <= 400):
+        findings.append(
+            PackageFinding("error", "story_pitch", "story.pitch 须 150–400 字、能复述全文，且不含数字")
+        )
+    elif _NUM_IN_PROSE.search(pitch):
+        findings.append(PackageFinding("error", "story_pitch", "story.pitch 一个数字都不许有"))
+    beats = [b for b in (story.get("beats") or []) if isinstance(b, Mapping)]
+    if len(beats) < 4:
+        findings.append(PackageFinding("error", "story_beats", "story.beats 至少 4 拍，每张主文表挂一拍"))
+    numbers = story.get("story_numbers") or []
+    if isinstance(numbers, list) and len(numbers) > 3:
+        findings.append(PackageFinding("error", "story_numbers", "摘要/结论最多 3 个故事数字"))
+    if pkg.get("h1_rejected") is True:
+        findings.append(
+            PackageFinding("error", "h1_rejected", "H1 必须是主发现；对不上就重定问题，不能标 h1_rejected")
+        )
+    return findings
+
+
 def write_gate(pkg: Mapping[str, Any]) -> list[PackageFinding]:
-    """Four-way conjunction. Passing one door is not enough."""
+    """Five-way conjunction. Passing one door is not enough."""
     findings = validate_package(pkg)
     mode = str(pkg.get("mode") or "")
     null_effect = bool(pkg.get("null_effect"))
@@ -452,6 +619,34 @@ def audit_manuscript(text: str, pkg: Mapping[str, Any] | None = None) -> list[Pa
                 "假说不要写成平行趋势/PSM/泊松/匹配等识别诊断",
             )
         )
+    for phrase in _WORK_LANGUAGE:
+        if phrase in body:
+            findings.append(
+                PackageFinding(
+                    "error",
+                    "work_language",
+                    f"正文出现工作语言 {phrase!r}：那是想问题用的词，不是刊面用词",
+                )
+            )
+    if _H1_REJECTED.search(body):
+        findings.append(
+            PackageFinding(
+                "error",
+                "h1_rejected",
+                "结论/摘要不得写「H1 被拒绝」：主假说必须是主发现，对不上就重定问题",
+            )
+        )
+    if pkg is not None:
+        story = pkg.get("story") if isinstance(pkg.get("story"), Mapping) else {}
+        answer = str(story.get("answer") or "").strip()
+        if answer and not _answer_covered(answer, body):
+            findings.append(
+                PackageFinding(
+                    "error",
+                    "story_not_in_text",
+                    "story.answer 须能在摘要或结论里复述出来（无数字答案句）",
+                )
+            )
     if "依然成立" in body and pkg is not None:
         fig = pkg.get("figure_gate") if isinstance(pkg.get("figure_gate"), Mapping) else {}
         cross0 = int(fig.get("event_post_cross0_n") or 0)

--- a/tests/test_empirical_package.py
+++ b/tests/test_empirical_package.py
@@ -64,23 +64,48 @@ def _ok_core() -> dict:
         },
         "main_col": "(4)",
         "main_p": 0.01,
-        "mechanism_channels": ["批发零售新注册"],
+        "mechanism_channels": ["批发零售新注册", "居民服务新注册"],
         "mechanism_methods": ["jiangting", "sobel"],
         "mechanism_lock": ["信息化"],
         "mechanism_theory": "示范改变流通进入 → 批发零售新注册上升 → 县域贷款对数因此上升",
+        "framework": "基于信息不对称下的金融中介框架，处理通过流通进入改变县域信贷",
+        "policy_type": "mixed",
+        "policy_type_basis": "商务部示范名单叠加财政专项资金到县",
         "figure_gate": {
             "event_post_n": 4,
             "event_post_cross0_n": 0,
             "placebo_true_outside_mass": True,
             "event0_job": "名单公布年，资金同步下达所以 0 点最高",
         },
+        "story": {
+            "question": "那么，电商示范名单能否提高县域贷款对数？",
+            "tension": "示范既可能引入真实信贷需求，也可能只是把已有网点的业务换个统计口径。",
+            "answer": "名单县的流通进入上升，并带动县域信贷相对扩张",
+            "pitch": (
+                "问题是示范名单有没有把信贷做厚。难处在于名单县本来条件更好，"
+                "对照并不干净，也说不清扩张来自真实需求还是统计口径。我们用县年"
+                "双重差分，先看贷款相对变化，再看流通进入这条独立于控制的渠道。"
+                "发现名单县信贷相对扩张，说明示范不只是换统计口径，而是把可贷"
+                "需求做厚了。这意味着县域信贷政策要把流通进入当作可核对的中间站，"
+                "而不是只看年末贷款余额本身。"
+            ),
+            "beats": [
+                {"section": "基准", "asks": "Y相对变了吗", "tables": [2], "answer": "相对扩张"},
+                {"section": "识别", "asks": "是不是选择", "tables": [3], "answer": "站住了"},
+                {"section": "机制", "asks": "流通进入动了吗", "tables": [4], "answer": "动了"},
+                {"section": "异质", "asks": "哪里更强", "tables": [5], "answer": "中西部更强"},
+            ],
+            "story_numbers": ["主效应实物量级"],
+        },
     }
 
 
 def test_thinking_questions_are_reusable_not_a_menu():
-    assert len(THINKING_QUESTIONS) == 10
+    assert len(THINKING_QUESTIONS) >= 10
     assert any("观察点" in q for q in THINKING_QUESTIONS)
     assert any("贴纸" in q for q in THINKING_QUESTIONS)
+    assert any("故事页" in q for q in THINKING_QUESTIONS)
+    assert any("推断家族" in q for q in THINKING_QUESTIONS)
 
 
 def test_ok_core_package_passes_write_gate():
@@ -128,9 +153,41 @@ def test_dirty_event_study_blocks_even_if_twfe_is_starred():
     assert "placebo_figure" in codes
 
 
+def test_same_family_methods_count_as_one():
+    from scripts.core.empirical_package import method_families, validate_package
+
+    pkg = _ok_core()
+    pkg["mechanism_methods"] = ["sobel", "bootstrap"]
+    assert method_families(pkg["mechanism_methods"]) == ["stepwise_indirect"]
+    codes = {f.code for f in validate_package(pkg) if f.severity == "error"}
+    assert "mechanism_methods" in codes
+
+
+def test_mechanism_cannot_be_the_outcome():
+    pkg = _ok_core()
+    pkg["mechanism_channels"] = ["县域贷款对数", "批发零售新注册"]
+    codes = {f.code for f in validate_package(pkg) if f.severity == "error"}
+    assert "mechanism_is_y" in codes
+
+
+def test_core_needs_a_story_page():
+    pkg = _ok_core()
+    pkg["story"] = {}
+    codes = {f.code for f in validate_package(pkg) if f.severity == "error"}
+    assert "story" in codes
+
+
+def test_h1_rejected_is_a_rewrite_not_a_finding():
+    text = "结论：假说H1被拒绝，政策没有提高贷款。\n前站没有接上后站。"
+    codes = {f.code for f in audit_manuscript(text, _ok_core())}
+    assert "h1_rejected" in codes
+    assert "work_language" in codes
+
+
 def test_manuscript_memo_voice_and_doi():
     text = (
-        "摘要：本文不是估计 ATT，不应解释为因果。\n"
+        "摘要：本文不是估计 ATT，不应解释为因果。"
+        "名单县的流通进入上升，并带动县域信贷相对扩张。\n"
         "研究发现平行趋势、安慰剂后依然成立。\n"
         "H1：平行趋势成立。\n"
         "参考文献\n"


### PR DESCRIPTION
## Summary
- Read-only pass over the 实证分析 `科研架构底座` (Sept 3–4 updates): story page, mechanism method families, H1 = finding, M ≠ Y.
- Ported only reusable contracts into `scripts/core/empirical_package.py`. Did **not** copy phrasebooks, `LINE_LOCKS`, paper coefficients, or the 160KB Chinese scanner.
- Write-gate conjunction is now five-way: significant main ∧ jobs ∧ live T→M ∧ clean figures ∧ retellable `story`. Core needs ≥2 channels that are not Y, and two methods from different inference families.

## Test plan
- [x] `pytest tests/test_empirical_package.py -q` (18 passed)
- [x] audit_guard empirical-package wiring 5/5
- [ ] CI on this PR

Made with [Cursor](https://cursor.com)