### PR TITLE
fix: count mechanism families after normalizing aliases

### DIFF
--- a/scripts/core/empirical_package.py
+++ b/scripts/core/empirical_package.py
@@ -106,11 +106,11 @@ MECHANISM_METHOD_FAMILIES: dict[str, frozenset[str]] = {
 
 _POLICY_TYPES = frozenset({"project_system", "advocacy", "mixed", "not_policy"})
 _NUM_IN_PROSE = re.compile(r"\d+\.\d+|%")
-_H1_REJECTED = re.compile(r"假说\s*H\s*1.{0,8}(被拒绝|未得到验证)|H\s*1.{0,6}被拒绝")
+# Claim form only. "H1被拒绝的可能性" / "文献中 H1 常被拒绝" stay out.
+_H1_REJECTED = re.compile(r"(?:假说\s*)?H\s*1\s*(?:被拒绝|未得到验证)(?!的可能性)")
 _WORK_LANGUAGE = (
     "前站",
     "吸收层",
-    "名单效应",
     "框架的推论",
 )
 
@@ -171,17 +171,18 @@ def thinking_questions() -> tuple[str, ...]:
 
 def method_families(methods: Iterable[str]) -> list[str]:
     """Map method tokens to inference families; unknowns stay distinct."""
+    alias: dict[str, str] = {}
+    for name, aliases in MECHANISM_METHOD_FAMILIES.items():
+        alias[_norm(name)] = name
+        for raw_alias in aliases:
+            alias[_norm(raw_alias)] = name
     out: list[str] = []
     seen: set[str] = set()
     for raw in methods:
         token = _norm(str(raw))
         if not token:
             continue
-        family = f"other:{token}"
-        for name, aliases in MECHANISM_METHOD_FAMILIES.items():
-            if token in aliases or token == _norm(name):
-                family = name
-                break
+        family = alias.get(token, f"other:{token}")
         if family not in seen:
             seen.add(family)
             out.append(family)
@@ -391,7 +392,12 @@ def validate_package(pkg: Mapping[str, Any]) -> list[PackageFinding]:
                 "机制渠道不得是本题 Y（贷款题禁再印贷款对数/存量/深度）",
             )
         )
-    if mode == "core" and len(channels) < 2:
+    distinct_channels: list[str] = []
+    for channel in channels:
+        if any(_same_construct(channel, kept) for kept in distinct_channels):
+            continue
+        distinct_channels.append(channel)
+    if mode == "core" and len(distinct_channels) < 2:
         findings.append(
             PackageFinding(
                 "error",
@@ -500,7 +506,9 @@ def _validate_core_story_and_type(pkg: Mapping[str, Any]) -> list[PackageFinding
         findings.append(PackageFinding("error", "story_pitch", "story.pitch 一个数字都不许有"))
     beats = [b for b in (story.get("beats") or []) if isinstance(b, Mapping)]
     if len(beats) < 4:
-        findings.append(PackageFinding("error", "story_beats", "story.beats 至少 4 拍，每张主文表挂一拍"))
+        findings.append(
+            PackageFinding("error", "story_beats", "story.beats 至少 4 拍（基准 / 识别 / 机制 / 异质）")
+        )
     numbers = story.get("story_numbers") or []
     if isinstance(numbers, list) and len(numbers) > 3:
         findings.append(PackageFinding("error", "story_numbers", "摘要/结论最多 3 个故事数字"))

--- a/tests/test_empirical_package.py
+++ b/tests/test_empirical_package.py
@@ -163,6 +163,50 @@ def test_same_family_methods_count_as_one():
     assert "mechanism_methods" in codes
 
 
+def test_underscored_aliases_stay_in_the_same_family():
+    from scripts.core.empirical_package import method_families
+
+    assert method_families(["did_x_base_m", "moderation", "treat_x_baseline"]) == [
+        "moderation"
+    ]
+    assert method_families(["jiangting", "two_step", "did_on_m"]) == ["twostep"]
+    assert method_families(["m_in_y", "four_step"]) == ["stepwise_indirect"]
+
+
+def test_duplicate_channels_do_not_count_as_two_paths():
+    pkg = _ok_core()
+    pkg["mechanism_channels"] = ["批发零售新注册", "批发零售新注册"]
+    codes = {f.code for f in validate_package(pkg) if f.severity == "error"}
+    assert "mechanism_channels" in codes
+
+
+def test_gold_mode_does_not_require_story_or_policy_type():
+    from scripts.core.empirical_package import GOLD_SLOTS
+
+    pkg = empty_package(mode="gold", unit="firm")
+    pkg["y_construct"] = "绿色专利"
+    pkg["x_construct"] = "碳交易"
+    pkg["battery"] = ["规模", "杠杆", "成长"]
+    pkg["variable_jobs"] = [
+        {
+            "name": name,
+            "table_row": f"{name}水平",
+            "construct": name,
+            "job": f"挡绿色专利的事前{name}",
+            "basis": f"接到本题绿色专利的事前{name}，不是年鉴有",
+        }
+        for name in pkg["battery"]
+    ]
+    pkg["slots"] = {name: f"T{i}" for i, name in enumerate(GOLD_SLOTS, 1)}
+    pkg["main_col"] = "(1)"
+    pkg["main_p"] = 0.01
+    codes = {f.code for f in validate_package(pkg) if f.severity == "error"}
+    assert "story" not in codes
+    assert "policy_type" not in codes
+    assert "mechanism_channels" not in codes
+    assert codes == set()
+
+
 def test_mechanism_cannot_be_the_outcome():
     pkg = _ok_core()
     pkg["mechanism_channels"] = ["县域贷款对数", "批发零售新注册"]
@@ -182,6 +226,13 @@ def test_h1_rejected_is_a_rewrite_not_a_finding():
     codes = {f.code for f in audit_manuscript(text, _ok_core())}
     assert "h1_rejected" in codes
     assert "work_language" in codes
+
+
+def test_h1_possibility_and_published_words_are_not_workspace_voice():
+    text = "我们讨论 H1被拒绝的可能性，并回顾文献中的名单效应。"
+    codes = {f.code for f in audit_manuscript(text, _ok_core())}
+    assert "h1_rejected" not in codes
+    assert "work_language" not in codes
 
 
 def test_manuscript_memo_voice_and_doi():


### PR DESCRIPTION
## Summary
- Write-gate treated underscored aliases (`did_x_base_m`, `two_step`) as a second inference family after `_norm`, so same-family pairs could pass the two-method rule.
- Duplicate / same-construct channels (`批发零售新注册` twice, `县域贷款对数` + `县域贷款`) could pass the two-path rule.
- Tightened `H1被拒绝` to claim form only, and dropped `名单效应` from hard work-language so published wording is not blocked.

## Test plan
- [x] `pytest tests/test_empirical_package.py -q` (22 passed)
- [x] gold / forum / cross_section still skip story and `policy_type`
- [x] writing-only with no package still soft-skips
- [ ] CI on this PR


Made with [Cursor](https://cursor.com)